### PR TITLE
Ajout d’un composant Section

### DIFF
--- a/components/follow.js
+++ b/components/follow.js
@@ -4,7 +4,7 @@ const Follow = () => {
   const [isShown, setIsShown] = useState(false)
 
   return (
-    <div className='fr-follow'>
+    <div className='fr-follow fr-px-5w'>
       <div className='fr-container'>
         <div className='fr-grid-row'>
           <div className='fr-col-12 fr-col-md-8'>

--- a/components/follow.js
+++ b/components/follow.js
@@ -4,7 +4,7 @@ const Follow = () => {
   const [isShown, setIsShown] = useState(false)
 
   return (
-    <div className='fr-follow fr-px-5w'>
+    <div className='fr-follow fr-px-2w fr-px-lg-5w'>
       <div className='fr-container'>
         <div className='fr-grid-row'>
           <div className='fr-col-12 fr-col-md-8'>

--- a/components/section-image.js
+++ b/components/section-image.js
@@ -3,7 +3,7 @@ import Image from 'next/image'
 
 import colors from '@/styles/colors'
 
-const Section = ({title, subtitle, background, image, imageSide, panelBottom, children, ...props}) => (
+const SectionImage = ({title, subtitle, background, image, imageSide, panelBottom, children, ...props}) => (
   <section className={background} {...props}>
     <div className={`content-wrapper ${image ? 'illustrated' : ''}`}>
       {image && (
@@ -117,7 +117,7 @@ const Section = ({title, subtitle, background, image, imageSide, panelBottom, ch
   </section>
 )
 
-Section.propTypes = {
+SectionImage.propTypes = {
   title: PropTypes.string,
   subtitle: PropTypes.string,
   image: PropTypes.string,
@@ -135,7 +135,7 @@ Section.propTypes = {
   panelBottom: PropTypes.node
 }
 
-Section.defaultProps = {
+SectionImage.defaultProps = {
   title: null,
   subtitle: null,
   image: null,
@@ -145,4 +145,5 @@ Section.defaultProps = {
   imageSide: 'left'
 }
 
-export default Section
+export default SectionImage
+

--- a/components/section-image.js
+++ b/components/section-image.js
@@ -4,10 +4,10 @@ import Image from 'next/image'
 import colors from '@/styles/colors'
 
 const SectionImage = ({title, subtitle, background, image, imageSide, panelBottom, children, ...props}) => (
-  <section className={background} {...props}>
+  <section className={`fr-py-4w ${background}`} {...props}>
     <div className={`content-wrapper ${image ? 'illustrated' : ''}`}>
       {image && (
-        <div className='illustration'>
+        <div className='illustration fr-m-auto'>
           <Image
             src={image}
             height={300}
@@ -18,10 +18,10 @@ const SectionImage = ({title, subtitle, background, image, imageSide, panelBotto
       )}
 
       <div className='rows-section'>
-        <div className='titles'>
-          <h3>{title}</h3>
+        <div className='fr-mb-4w'>
+          <h2>{title}</h2>
           <div className='subtitle fr-text fr-text--lg'>
-            {subtitle}
+            <b>{subtitle}</b>
           </div>
         </div>
         {children}
@@ -29,19 +29,13 @@ const SectionImage = ({title, subtitle, background, image, imageSide, panelBotto
     </div>
 
     {panelBottom && (
-      <div className='panel'>
+      <div className='fr-col-12 fr-mt-n4w'>
         {panelBottom}
       </div>
     )}
 
     <style jsx>{`
-      .panel {
-        margin-top: -3em;
-        width: 100%;
-      }
-
       section {
-        padding: 2em 0;
         display: flex;
         flex-direction: column;
         justify-content: center;
@@ -56,7 +50,7 @@ const SectionImage = ({title, subtitle, background, image, imageSide, panelBotto
         background: ${colors.grey975};
       }
 
-      .color {
+      .blue {
         background: ${colors.info200};
         color: white;
       }
@@ -66,13 +60,14 @@ const SectionImage = ({title, subtitle, background, image, imageSide, panelBotto
         color: white;
       }
 
-      h3 {
-        color: ${background === 'color' || background === 'dark' ? 'white' : ''}
+      h2 {
+        text-align: center;
+        color: ${background === 'color' || background === 'dark' ? 'white' : ''};
       }
 
       .subtitle {
          color: ${colors.grey200};
-         font-weight: bold;
+         text-align: center;
       }
 
       .content-wrapper {
@@ -90,28 +85,16 @@ const SectionImage = ({title, subtitle, background, image, imageSide, panelBotto
         flex-wrap: wrap;
       }
 
-      .titles {
-        margin-bottom: 3em;
-      }
-
       .illustration {
-       flex: 1;
-       display: flex;
-       justify-content: center;
-       align-items: center;
+        flex: 1;
       }
 
       .rows-section {
-        text-align: center;
         flex: 2;
       }
 
       p {
         text-align: ${image ? 'left' : 'center'}
-      }
-
-      h3 {
-        margin-bottom: 0.5em;
       }
     `}</style>
   </section>
@@ -124,7 +107,7 @@ SectionImage.propTypes = {
   background: PropTypes.oneOf([
     'primary',
     'secondary',
-    'color',
+    'blue',
     'dark'
   ]),
   imageSide: PropTypes.oneOf([

--- a/components/section-image.js
+++ b/components/section-image.js
@@ -1,0 +1,148 @@
+import PropTypes from 'prop-types'
+import Image from 'next/image'
+
+import colors from '@/styles/colors'
+
+const Section = ({title, subtitle, background, image, imageSide, panelBottom, children, ...props}) => (
+  <section className={background} {...props}>
+    <div className={`content-wrapper ${image ? 'illustrated' : ''}`}>
+      {image && (
+        <div className='illustration'>
+          <Image
+            src={image}
+            height={300}
+            width={300}
+            alt=''
+          />
+        </div>
+      )}
+
+      <div className='rows-section'>
+        <div className='titles'>
+          <h3>{title}</h3>
+          <div className='subtitle fr-text fr-text--lg'>
+            {subtitle}
+          </div>
+        </div>
+        {children}
+      </div>
+    </div>
+
+    {panelBottom && (
+      <div className='panel'>
+        {panelBottom}
+      </div>
+    )}
+
+    <style jsx>{`
+      .panel {
+        margin-top: -3em;
+        width: 100%;
+      }
+
+      section {
+        padding: 2em 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .primary {
+        background: white;
+      }
+
+      .secondary {
+        background: ${colors.grey975};
+      }
+
+      .color {
+        background: ${colors.info200};
+        color: white;
+      }
+
+      .dark {
+        background: ${colors.darkgrey};
+        color: white;
+      }
+
+      h3 {
+        color: ${background === 'color' || background === 'dark' ? 'white' : ''}
+      }
+
+      .subtitle {
+         color: ${colors.grey200};
+         font-weight: bold;
+      }
+
+      .content-wrapper {
+        display: flex;
+        justify-content: center;
+        gap: 1em;
+        width: 80%;
+        padding: 5em 0;
+      }
+
+      .illustrated {
+        display: flex;
+        flex-direction: ${imageSide === 'right' ? 'row-reverse' : 'row'};
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      .titles {
+        margin-bottom: 3em;
+      }
+
+      .illustration {
+       flex: 1;
+       display: flex;
+       justify-content: center;
+       align-items: center;
+      }
+
+      .rows-section {
+        text-align: center;
+        flex: 2;
+      }
+
+      p {
+        text-align: ${image ? 'left' : 'center'}
+      }
+
+      h3 {
+        margin-bottom: 0.5em;
+      }
+    `}</style>
+  </section>
+)
+
+Section.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  image: PropTypes.string,
+  background: PropTypes.oneOf([
+    'primary',
+    'secondary',
+    'color',
+    'dark'
+  ]),
+  imageSide: PropTypes.oneOf([
+    'left',
+    'right'
+  ]),
+  children: PropTypes.node,
+  panelBottom: PropTypes.node
+}
+
+Section.defaultProps = {
+  title: null,
+  subtitle: null,
+  image: null,
+  children: null,
+  panelBottom: null,
+  background: 'primary',
+  imageSide: 'left'
+}
+
+export default Section

--- a/components/section-image.js
+++ b/components/section-image.js
@@ -3,19 +3,17 @@ import Image from 'next/image'
 
 import colors from '@/styles/colors'
 
-const SectionImage = ({title, subtitle, background, image, imageSide, panelBottom, children, ...props}) => (
+const SectionImage = ({title, subtitle, background, imageLink, imageSide, panelBottom, children, ...props}) => (
   <section className={`fr-py-4w ${background}`} {...props}>
-    <div className={`content-wrapper ${image ? 'illustrated' : ''}`}>
-      {image && (
-        <div className='illustration fr-m-auto'>
-          <Image
-            src={image}
-            height={300}
-            width={300}
-            alt=''
-          />
-        </div>
-      )}
+    <div className={`content-wrapper ${imageLink ? 'illustrated' : ''}`}>
+      <div className='illustration fr-m-auto'>
+        <Image
+          src={imageLink}
+          height={300}
+          width={300}
+          alt=''
+        />
+      </div>
 
       <div className='rows-section'>
         <div className='fr-mb-4w'>
@@ -92,10 +90,6 @@ const SectionImage = ({title, subtitle, background, image, imageSide, panelBotto
       .rows-section {
         flex: 2;
       }
-
-      p {
-        text-align: ${image ? 'left' : 'center'}
-      }
     `}</style>
   </section>
 )
@@ -103,7 +97,7 @@ const SectionImage = ({title, subtitle, background, image, imageSide, panelBotto
 SectionImage.propTypes = {
   title: PropTypes.string,
   subtitle: PropTypes.string,
-  image: PropTypes.string,
+  imageLink: PropTypes.string.isRequired,
   background: PropTypes.oneOf([
     'primary',
     'secondary',
@@ -121,7 +115,6 @@ SectionImage.propTypes = {
 SectionImage.defaultProps = {
   title: null,
   subtitle: null,
-  image: null,
   children: null,
   panelBottom: null,
   background: 'primary',

--- a/components/section.js
+++ b/components/section.js
@@ -1,148 +1,69 @@
 import PropTypes from 'prop-types'
-import Image from 'next/image'
 
 import colors from '@/styles/colors'
 
-const Section = ({title, subtitle, background, image, imageSide, panelBottom, children, ...props}) => (
-  <section className={background} {...props}>
-    <div className={`content-wrapper ${image ? 'illustrated' : ''}`}>
-      {image && (
-        <div className='illustration'>
-          <Image
-            src={image}
-            height={300}
-            width={300}
-            alt=''
-          />
-        </div>
+const Section = ({title, subtitle, background, children, ...props}) => (
+  <section className={`fr-p-3w ${background}`} {...props}>
+    <div className='fr-container'>
+      {title && (
+        <h1 className='fr-pt-4w'>{title}</h1>
       )}
 
-      <div className='rows-section'>
-        <div className='titles'>
-          <h3>{title}</h3>
-          <div className='subtitle fr-text fr-text--lg'>
-            {subtitle}
-          </div>
-        </div>
+      {subtitle && (
+        <h3 className='fr-p-2w subtitle'>{subtitle}</h3>
+      )}
+
+      <div className='fr-grid fr-grid--gutter'>
         {children}
       </div>
     </div>
-
-    {panelBottom && (
-      <div className='panel'>
-        {panelBottom}
-      </div>
-    )}
-
     <style jsx>{`
-      .panel {
-        margin-top: -3em;
-        width: 100%;
-      }
-
-      section {
-        padding: 2em 0;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-      }
-
-      .primary {
-        background: white;
-      }
-
-      .secondary {
-        background: ${colors.grey975};
-      }
-
-      .color {
-        background: ${colors.info200};
-        color: white;
-      }
-
-      .dark {
-        background: ${colors.darkgrey};
-        color: white;
-      }
-
-      h3 {
-        color: ${background === 'color' || background === 'dark' ? 'white' : ''}
+      h1 {
+        color: ${(background === 'dark' || background === 'blue') ? 'white' : 'inherit'}
       }
 
       .subtitle {
-         color: ${colors.grey200};
-         font-weight: bold;
+        color: ${(background === 'dark' || background === 'blue') ? 'white' : colors.grey200}
+      }
+ 
+      .primary {
+        background-color: white;
       }
 
-      .content-wrapper {
-        display: flex;
-        justify-content: center;
-        gap: 1em;
-        width: 80%;
-        padding: 5em 0;
+      .secondary {
+        background-color: ${colors.grey975};
       }
 
-      .illustrated {
-        display: flex;
-        flex-direction: ${imageSide === 'right' ? 'row-reverse' : 'row'};
-        justify-content: center;
-        flex-wrap: wrap;
+      .dark {
+        background-color: ${colors.darkgrey};
+        color: white;
       }
 
-      .titles {
-        margin-bottom: 3em;
-      }
-
-      .illustration {
-       flex: 1;
-       display: flex;
-       justify-content: center;
-       align-items: center;
-      }
-
-      .rows-section {
-        text-align: center;
-        flex: 2;
-      }
-
-      p {
-        text-align: ${image ? 'left' : 'center'}
-      }
-
-      h3 {
-        margin-bottom: 0.5em;
+      .blue {
+        background-color: ${colors.info200};
+        color: white;
       }
     `}</style>
   </section>
 )
 
-Section.propTypes = {
-  title: PropTypes.string,
-  subtitle: PropTypes.string,
-  image: PropTypes.string,
-  background: PropTypes.oneOf([
-    'primary',
-    'secondary',
-    'color',
-    'dark'
-  ]),
-  imageSide: PropTypes.oneOf([
-    'left',
-    'right'
-  ]),
-  children: PropTypes.node,
-  panelBottom: PropTypes.node
-}
-
 Section.defaultProps = {
   title: null,
   subtitle: null,
-  image: null,
-  children: null,
-  panelBottom: null,
-  background: 'primary',
-  imageSide: 'left'
+  background: 'primary'
+}
+
+Section.propTypes = {
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  background: PropTypes.oneOf([
+    'primary',
+    'secondary',
+    'dark',
+    'blue'
+  ]),
+  children: PropTypes.node.isRequired
 }
 
 export default Section
+

--- a/components/section.js
+++ b/components/section.js
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types'
 import colors from '@/styles/colors'
 
 const Section = ({title, subtitle, background, children, ...props}) => (
-  <section className={`fr-p-3w ${background}`} {...props}>
+  <section className={`fr-p-3w fr-py-12w ${background}`} {...props}>
     <div className='fr-container'>
       {title && (
-        <h1 className='fr-pt-4w'>{title}</h1>
+        <h2 className='fr-pt-4w'>{title}</h2>
       )}
 
       {subtitle && (
-        <h3 className='fr-p-2w subtitle'>{subtitle}</h3>
+        <div className='fr-p-2w subtitle fr-text fr-text--lg'><b>{subtitle}</b></div>
       )}
 
       <div className='fr-grid fr-grid--gutter'>
@@ -18,7 +18,7 @@ const Section = ({title, subtitle, background, children, ...props}) => (
       </div>
     </div>
     <style jsx>{`
-      h1 {
+      h2 {
         color: ${(background === 'dark' || background === 'blue') ? 'white' : 'inherit'}
       }
 

--- a/pages/blog/lancement.js
+++ b/pages/blog/lancement.js
@@ -2,6 +2,7 @@ import Image from 'next/image'
 
 import Page from '@/layouts/main'
 import Follow from '@/components/follow'
+import SectionImage from '@/components/section-image'
 import Section from '@/components/section'
 
 const Lancement = () => (
@@ -10,8 +11,9 @@ const Lancement = () => (
     description='Création d’une Startup d’Etat afin de produire la documentation et le suivi nécessaire aux territoires concernés par des projets PCRS, par l’ANCT'
     type='article'
   >
-    <section className='fr-px-3w fr-my-8w'>
-      <h1 className='fr-py-4w'>Lancement</h1>
+    <Section
+      title='Lancement'
+    >
       <div className='fr-container fr-pb-3w' style={{textAlign: 'center'}}>
         <div className='fr-col-12'>
           <Image
@@ -55,8 +57,8 @@ const Lancement = () => (
       <p>
         Dans l’attente de prochains rendez-vous marquant la montée en puissance de notre initiative, nous nous tenons à votre disposition sur notre adresse de contact.
       </p>
-    </section>
-    <section className='fr-px-3w fr-my-8w'>
+    </Section>
+    <Section>
       <p>
         Lien du site : <a href='https://pcrs.beta.gouv.fr' className='fr-link fr-icon-links-line fr-link--icon-right'>pcrs.beta.gouv.fr</a>
       </p>
@@ -66,14 +68,14 @@ const Lancement = () => (
       <p>
         Adresse de contact : <a href='mailto:contact&#64;pcrs.beta.gouv.fr' className='fr-link fr-icon-links-line fr-link--icon-right'>contact&#64;pcrs.beta.gouv.fr</a>
       </p>
-    </section>
-    <Section
+    </Section>
+    <SectionImage
       title='Suivez l’actualité'
       subtitle='En vous inscrivant à la newsletter ou en nous suivant sur Twitter'
       background='secondary'
     >
       <Follow />
-    </Section>
+    </SectionImage>
     <style jsx>{`
       section {
         max-width: 1000px;

--- a/pages/blog/lancement.js
+++ b/pages/blog/lancement.js
@@ -69,13 +69,16 @@ const Lancement = () => (
         Adresse de contact : <a href='mailto:contact&#64;pcrs.beta.gouv.fr' className='fr-link fr-icon-links-line fr-link--icon-right'>contact&#64;pcrs.beta.gouv.fr</a>
       </p>
     </Section>
-    <SectionImage
+    <Section
       title='Suivez l’actualité'
       subtitle='En vous inscrivant à la newsletter ou en nous suivant sur Twitter'
       background='secondary'
+      style={{
+        textAlign: 'center'
+      }}
     >
       <Follow />
-    </SectionImage>
+    </Section>
     <style jsx>{`
       section {
         max-width: 1000px;

--- a/pages/declaration-accessibilite.js
+++ b/pages/declaration-accessibilite.js
@@ -5,11 +5,12 @@ import colors from '@/styles/colors'
 
 import Page from '@/layouts/main'
 
+import Section from '@/components/section'
 import Button from '@/components/button'
 
 const Accessibilite = () => (
   <Page title='Déclaration d’accessibilité' description='Consultez la déclaration d’accessibilité de pcrs.beta.gouv'>
-    <section className='fr-px-3w fr-py-3w fr-px-md-15w fr-py-md-10w'>
+    <Section>
       <div className='fr-container fr-pb-10w fr-pt-5w'>
         <div className='fr-grid-row fr-grid-row--center'>
           <div className='fr-col-12 fr-col-md-8'>
@@ -29,7 +30,7 @@ const Accessibilite = () => (
         </div>
       </div>
 
-      <h1>Déclaration d’accessibilité</h1>
+      <h2>Déclaration d’accessibilité</h2>
       <p>
         <b>pcrs.beta.gouv</b> s’engage à rendre ses sites internet, intranet, extranet et ses progiciels <b>accessibles</b> (et ses applications mobiles et mobilier urbain numérique) conformément à <b>l’article 47 de la loi n°2005-102 du 11 février 2005</b>. À cette fin, elle met en œuvre la stratégie et les actions suivantes :
       </p>
@@ -47,19 +48,23 @@ const Accessibilite = () => (
           </div>
         </div>
       </div>
-    </section>
+    </Section>
 
-    <section className='fr-px-3w fr-py-3w fr-px-md-15w fr-py-md-10w section-color'>
-      <h2 className='fr-mb-7w'>État de conformité</h2>
+    <Section
+      title='État de conformité'
+      background='blue'
+    >
       <div className='fr-alert fr-alert--error'>
         <h3 className='fr-alert__title'>Non-conforme</h3>
       </div>
 
       <p className='fr-pt-5w'><b>pcrs.beta.gouv.fr</b> est <b>non-conforme</b> avec le <b>référentiel général d’amélioration de l’accessibilité (RGAA)</b>, un audit d’accessibilité n’ayant pas encore été réalisé. L’absence d’audit d’accessibilité ne remet pas en cause le <b>caractère accessible</b> du site web actuel.</p>
-    </section>
+    </Section>
 
-    <section className='fr-px-3w fr-py-3w fr-px-md-15w fr-py-md-10w section-secondary'>
-      <h2>Information et contact</h2>
+    <Section
+      title='Informations et contact'
+      background='secondary'
+    >
       <p>Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez <b>contacter notre équipe</b> pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.</p>
 
       <Button
@@ -69,10 +74,11 @@ const Accessibilite = () => (
       >
         <span className='fr-icon-mail-line' aria-hidden='true' />&nbsp;Nous contacter
       </Button>
-    </section>
+    </Section>
 
-    <section className='fr-px-3w fr-py-3w fr-px-md-15w fr-py-md-10w'>
-      <h2>Voie de recours</h2>
+    <Section
+      title='Voie de recours'
+    >
       <p>
         Si vous constatez un défaut d’accessibilité vous empêchant d’accéder à un contenu ou une fonctionnalité du site, que vous nous le signalez et que vous ne parvenez pas à obtenir une réponse de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits.
         Plusieurs moyens sont à votre disposition :
@@ -89,7 +95,7 @@ const Accessibilite = () => (
         </li>
       </ul>
       <div />
-    </section>
+    </Section>
 
     <style jsx>{`
       .fr-alert--error {

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,7 +6,7 @@ import Page from '@/layouts/main'
 import colors from '@/styles/colors'
 
 import Hero from '@/components/hero'
-import Section from '@/components/section'
+import SectionImage from '@/components/section-image'
 import Button from '@/components/button'
 import Follow from '@/components/follow'
 import PcrsIframeMap from '@/components/pcrs-iframe-map'
@@ -31,7 +31,7 @@ const Home = () => {
         `}</style>
       </>
 
-      <Section
+      <SectionImage
         title='Documentation'
         image='/images/illustrations/doc_illustration.png'
         id='documentation'
@@ -91,9 +91,9 @@ const Home = () => {
             gap: 10px;
           }
         `}</style>
-      </Section>
+      </SectionImage>
 
-      <Section
+      <SectionImage
         title='Suivi géographique'
         subtitle=''
         background='secondary'
@@ -128,9 +128,9 @@ const Home = () => {
             width: 100%;
           }
         `}</style>
-      </Section>
+      </SectionImage>
 
-      <Section
+      <SectionImage
         title='Feuille de route'
         subtitle='Les étapes suivantes marqueront le développement de ce portail'
         image='/images/illustrations/progress_illustration.png'
@@ -159,9 +159,9 @@ const Home = () => {
             gap: 10px;
           }
         `}</style>
-      </Section>
+      </SectionImage>
 
-      <Section
+      <SectionImage
         title='Événements autour du PCRS'
         background='color'
         id='evenements'
@@ -195,9 +195,9 @@ const Home = () => {
             gap: 1em;
           }
         `}</style>
-      </Section>
+      </SectionImage>
 
-      <Section
+      <SectionImage
         title='Contactez-nous'
         subtitle='Vous ne trouvez pas les réponses à vos questions sur ce site ou dans la documentation ?'
         id='contact'
@@ -215,15 +215,15 @@ const Home = () => {
         >
           <span className='fr-icon-mail-line' aria-hidden='true' />&nbsp;Contactez-nous
         </Button>
-      </Section>
+      </SectionImage>
 
-      <Section
+      <SectionImage
         title='Suivez l’actualité'
         subtitle='En vous inscrivant à la newsletter ou en nous suivant sur Twitter'
         background='secondary'
       >
         <Follow />
-      </Section>
+      </SectionImage>
     </Page>
   )
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,7 +34,7 @@ const Home = () => {
 
       <SectionImage
         title='Documentation'
-        image='/images/illustrations/doc_illustration.png'
+        imageLink='/images/illustrations/doc_illustration.png'
         id='documentation'
       >
         <p>
@@ -98,7 +98,7 @@ const Home = () => {
         title='Suivi géographique'
         subtitle=''
         background='secondary'
-        image='/images/illustrations/geo_illustration.png'
+        imageLink='/images/illustrations/geo_illustration.png'
         imageSide='right'
         id='suivi-geo'
         panelBottom={isMapShown ? <PcrsIframeMap /> : null}
@@ -134,7 +134,7 @@ const Home = () => {
       <SectionImage
         title='Feuille de route'
         subtitle='Les étapes suivantes marqueront le développement de ce portail'
-        image='/images/illustrations/progress_illustration.png'
+        imageLink='/images/illustrations/progress_illustration.png'
         id='feuille-de-route'
       >
         <ul className='fr-text--sm dev-list'>

--- a/pages/index.js
+++ b/pages/index.js
@@ -177,7 +177,7 @@ const Home = () => {
           alt=''
           className='fr-m-1v'
         />
-        <div className='fr-p-4w'>
+        <div className='fr-p-2w fr-p-lg-4w'>
           <p className='fr-py-1w'>
             Tenez-vous informé des prochains événements organisés par l’ANCT à propos du PCRS. Ateliers, conférences, annonces pour être toujours à jour.
           </p>
@@ -199,7 +199,7 @@ const Home = () => {
           textAlign: 'center'
         }}
       >
-        <div className='fr-px-5w'>
+        <div className='fr-px-2w fr-px-lg-5w'>
           <p>
             Vous pouvez nous contacter !
           </p>

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,7 @@ import colors from '@/styles/colors'
 
 import Hero from '@/components/hero'
 import SectionImage from '@/components/section-image'
+import Section from '@/components/section'
 import Button from '@/components/button'
 import Follow from '@/components/follow'
 import PcrsIframeMap from '@/components/pcrs-iframe-map'
@@ -161,19 +162,23 @@ const Home = () => {
         `}</style>
       </SectionImage>
 
-      <SectionImage
+      <Section
         title='Événements autour du PCRS'
-        background='color'
+        background='blue'
         id='evenements'
+        style={{
+          textAlign: 'center'
+        }}
       >
         <Image
           src='/images/illustrations/calendar_illustration.png'
           height={200}
           width={200}
           alt=''
+          className='fr-m-1v'
         />
-        <div className='event-infos'>
-          <p>
+        <div className='fr-p-4w'>
+          <p className='fr-py-1w'>
             Tenez-vous informé des prochains événements organisés par l’ANCT à propos du PCRS. Ateliers, conférences, annonces pour être toujours à jour.
           </p>
           <Button
@@ -184,46 +189,43 @@ const Home = () => {
             Évènements à venir
           </Button>
         </div>
+      </Section>
 
-        <style jsx>{`
-          .event-infos {
-            margin-top: 2em;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            gap: 1em;
-          }
-        `}</style>
-      </SectionImage>
-
-      <SectionImage
+      <Section
         title='Contactez-nous'
         subtitle='Vous ne trouvez pas les réponses à vos questions sur ce site ou dans la documentation ?'
         id='contact'
+        style={{
+          textAlign: 'center'
+        }}
       >
-        <p>
-          Vous pouvez nous contacter !
-        </p>
-        <p>
-          Notre équipe fera le nécessaire pour vous répondre dans les plus brefs délais, dans la limite de sa disponibilité.
-        </p>
-        <Button
-          href='mailto:contact@pcrs.beta.gouv.fr'
-          isExternal
-          label='Contacter l’équipe'
-        >
-          <span className='fr-icon-mail-line' aria-hidden='true' />&nbsp;Contactez-nous
-        </Button>
-      </SectionImage>
+        <div className='fr-px-5w'>
+          <p>
+            Vous pouvez nous contacter !
+          </p>
+          <p>
+            Notre équipe fera le nécessaire pour vous répondre dans les plus brefs délais, dans la limite de sa disponibilité.
+          </p>
+          <Button
+            href='mailto:contact@pcrs.beta.gouv.fr'
+            isExternal
+            label='Contacter l’équipe'
+          >
+            <span className='fr-icon-mail-line' aria-hidden='true' />&nbsp;Contactez-nous
+          </Button>
+        </div>
+      </Section>
 
-      <SectionImage
+      <Section
         title='Suivez l’actualité'
         subtitle='En vous inscrivant à la newsletter ou en nous suivant sur Twitter'
         background='secondary'
+        style={{
+          textAlign: 'center'
+        }}
       >
         <Follow />
-      </SectionImage>
+      </Section>
     </Page>
   )
 }

--- a/pages/mentions-legales.js
+++ b/pages/mentions-legales.js
@@ -1,10 +1,12 @@
 import Page from '@/layouts/main'
+import Section from '@/components/section'
 
 const MentionsLegales = () => (
   <Page title='Mentions légales' description='Mentions légales relatives au site pcrs.beta.gouv.fr'>
-    <section className='fr-p-3w'>
-      <h1>Mentions légales</h1>
-      <h2>Données personnelles</h2>
+    <Section
+      title='Mentions légales'
+    >
+      <h4>Données personnelles</h4>
       <p>
         Les données recueillies ou traitées sont hébergées en France ou en Union Européenne.
       </p>
@@ -14,13 +16,11 @@ const MentionsLegales = () => (
       <p>
         Ce droit s’exerce auprès de l’Agence Nationale de la Cohésion des Territoires, 20 avenue de Ségur, 75007 Paris. <br />dpo [à] anct.gouv.fr
       </p>
-    </section>
-    <section className='fr-p-3w'>
-      <h2>Nous contacter</h2>
+      <h4>Nous contacter</h4>
       <p>
         <a href='mailto:contact&#64;pcrs.beta.gouv.fr'>contact&#64;pcrs.beta.gouv.fr</a>
       </p>
-      <h3>Éditeur</h3>
+      <h5>Éditeur</h5>
       <p>
         Agence Nationale de la Cohésion des Territoires <br /> 20, avenue de Ségur 75007 Paris
       </p>
@@ -30,20 +30,14 @@ const MentionsLegales = () => (
       <p>
         Directeur de publication : Yves Le Breton, ANCT
       </p>
-      <h3>Hébergeur</h3>
+      <h5>Hébergeur</h5>
       <p>
         société Scalingo SAS <br /> Code APE 6311Z
       </p>
       <p>
         Siège social : <br /> 3, place de Haguenau <br /> 67000 Strasbourg - France
       </p>
-    </section>
-    <style jsx>{`
-      section {
-        max-width: 1000px;
-        margin: auto;
-      }
-    `}</style>
+    </Section>
   </Page>
 )
 


### PR DESCRIPTION
Cette PR propose d’ajouter un composant `Section` facilement réutilisable.
Le précédent composant `Section` a été renommé `SectionImage` .

Les paramètres du nouveau composant sont les suivants : 
- `title` : Titre de la section
- `subtitle` : Sous-titre de la section
- `background` : couleur de l’arrière-plan de la section : 
    - `primary`
    - `secondary`
    - `dark`
    - `blue`
- `children` : composant enfant de la section