### PR TITLE
Suppression d'un import non utilisé

### DIFF
--- a/pages/blog/lancement.js
+++ b/pages/blog/lancement.js
@@ -2,7 +2,6 @@ import Image from 'next/image'
 
 import Page from '@/layouts/main'
 import Follow from '@/components/follow'
-import SectionImage from '@/components/section-image'
 import Section from '@/components/section'
 
 const Lancement = () => (


### PR DESCRIPTION
Un oubli a causé le fait que `SectionImage` était importé dans la page `/blog/lancement` alors que ce composant n'est pas utilisé.

