### PR TITLE
Correction de style sur les boutons

### DIFF
--- a/components/event-carousel.js
+++ b/components/event-carousel.js
@@ -38,7 +38,7 @@ const EventCarousel = () => {
               label={`${index === idx ? 'Vous consultez' : 'Aller à '} l’évènement ${event.title} du ${dateWithDay(event.date)}`}
               key={`${event.title}-${event.date}`}
               disabled={index === idx}
-              className='fr-m-0 fr-p-0'
+              className='dot-button fr-m-0 fr-p-0'
             >
               <div className={`slideshow-dot ${index === idx ? '' : 'disable'}`} />
             </button>
@@ -93,6 +93,10 @@ const EventCarousel = () => {
         }
 
           /* Buttons */
+        .dot-button:hover {
+          background: none;
+        }
+
         .slideshow-dots {
           display: grid;
           grid-template-columns: 18px 18px 18px;

--- a/pages/index.js
+++ b/pages/index.js
@@ -185,7 +185,7 @@ const Home = () => {
           </p>
           <Button
             href='/evenements'
-            buttonStyle='secondary-outline'
+            buttonStyle='secondary'
             label='Évenement à venir'
             isWhite
           >


### PR DESCRIPTION
- Suppression du background blanc au hover des boutons de contrôle du slider d'événements.
- Changement du nom de style pour le bouton menant à la page `evenements` sur la page d'accueil.