### PR TITLE
Correction de l'affichage du titre de la page (meta)

### DIFF
--- a/components/meta.js
+++ b/components/meta.js
@@ -9,7 +9,7 @@ const Meta = ({title, description, type, image}) => {
 
   return (
     <Head>
-      {title ? <title>{title} | {SITE_NAME}</title> : <title>{SITE_NAME}</title>}
+      <title>{title ? `${title} | ${SITE_NAME}` : SITE_NAME}</title>
       <link rel='icon' type='image/x-icon' href='/images/favicon.ico' />
 
       {/* Search Engine */}


### PR DESCRIPTION
La balise `<title />`  dans le composant `<Head />` de **Next.js** ne chargeait pas en priorité le contenu de la props `title`.
![Enregistrement de l’écran 2023-01-03 à 17 19 46](https://user-images.githubusercontent.com/66621960/210403955-5681dc89-d029-4e30-8f1f-145fff492a24.gif)

La création de la balise et de son contenu était conditionnée suivant la présence ou non d'un titre passé dans le layout de la page (`main.js`).
La solution était de plutôt conditionner seulement le contenu de la balise `<title />`


