### PR TITLE
Correction de l'affichage des évents à venir

### DIFF
--- a/pages/evenements.js
+++ b/pages/evenements.js
@@ -29,7 +29,7 @@ const Evenements = () => {
     const sortedNextMonthEvents = filteredFuturEvents.filter(event => {
       const [year, month] = event.date.split('-')
 
-      return currentYear < year || (currentMonth < Number(month) && currentYear === year)
+      return currentYear < year || (currentMonth < Number(month) && currentYear === Number(year))
     })
 
     setCurrentMonthEvents(sortedCurrentMonthEvents)


### PR DESCRIPTION
Correction d'une erreur de type faussant le filtrage des événements à venir.

**### AVANT**
<img width="1068" alt="Capture d’écran 2023-01-26 à 09 33 46" src="https://user-images.githubusercontent.com/66621960/214790837-96840124-ff8b-4adf-a3c0-4ef38e8ab743.png">

**### APRÈS**
<img width="1060" alt="Capture d’écran 2023-01-26 à 09 33 32" src="https://user-images.githubusercontent.com/66621960/214790839-d34813ff-3b72-4b36-a76b-a1d87941b626.png">