### PR TITLE
Correction de l'url du serveur dans les log

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -18,5 +18,5 @@ server.get('*', (req, res) => {
 })
 
 server.listen(port, () => {
-  console.log(`Go to http://localhost:${port}!`)
+  console.log(`Go to http://localhost:${port} !`)
 })


### PR DESCRIPTION
Ajout d'un espace entre l'url et le point d'exclamation afin d'éviter de fausser l'url affichée dans le log

```
server.listen(port, () => {
  console.log(`Go to http://localhost:${port}!`)
})
```

devient

```
server.listen(port, () => {
  console.log(`Go to http://localhost:${port} !`)
})
```