### PR TITLE
Ajout de composant inputs

### DIFF
--- a/components/date-input.js
+++ b/components/date-input.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types'
 
-const DateInput = ({label, value, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
+const DateInput = ({label, value, ariaLabel, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
   const inputState = errorMessage ? 'error' : ''
 
   return (
     <div className='fr-input-group'>
-      <label className='fr-label' htmlFor='text-input-calendar'>{label}</label>
+      <label className='fr-label'>{label}</label>
       {description && <span className='fr-hint-text fr-mb-2w'>{description}</span>}
 
       <div className='fr-input-wrap fr-fi-calendar-line'>
@@ -13,7 +13,7 @@ const DateInput = ({label, value, errorMessage, description, isRequired, isDisab
           className={`fr-input fr-input--${inputState}`}
           type='date'
           value={value}
-          name={name}
+          aria-label={ariaLabel}
           required={isRequired}
           disabled={isDisabled}
           onChange={e => onValueChange(e.target.value)}
@@ -28,7 +28,7 @@ const DateInput = ({label, value, errorMessage, description, isRequired, isDisab
 DateInput.propTypes = {
   label: PropTypes.string,
   value: PropTypes.string,
-  name: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string,
   errorMessage: PropTypes.string,
   description: PropTypes.string,
   isRequired: PropTypes.bool,
@@ -39,6 +39,7 @@ DateInput.propTypes = {
 DateInput.defaultProps = {
   label: '',
   value: '',
+  ariaLabel: '',
   errorMessage: null,
   description: null,
   isRequired: false,

--- a/components/date-input.js
+++ b/components/date-input.js
@@ -26,7 +26,7 @@ const DateInput = ({label, value, errorMessage, description, isRequired, isDisab
 }
 
 DateInput.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   value: PropTypes.string,
   name: PropTypes.string.isRequired,
   errorMessage: PropTypes.string,
@@ -37,6 +37,7 @@ DateInput.propTypes = {
 }
 
 DateInput.defaultProps = {
+  label: '',
   value: '',
   errorMessage: null,
   description: null,

--- a/components/date-input.js
+++ b/components/date-input.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types'
+
+const DateInput = ({label, value, name, errorMessage, description, isRequired, isDisable, onValueChange}) => {
+  const inputState = errorMessage ? 'error' : ''
+
+  return (
+    <div className='fr-input-group'>
+      <label className='fr-label' htmlFor='text-input-calendar'>{label}</label>
+      {description && <span className='fr-hint-text fr-mb-2w'>{description}</span>}
+
+      <div className='fr-input-wrap fr-fi-calendar-line'>
+        <input
+          className={`fr-input fr-input--${inputState}`}
+          type='date'
+          value={value}
+          name={name}
+          required={isRequired}
+          disabled={isDisable}
+          onChange={e => onValueChange(e.target.value)}
+        />
+      </div>
+
+      {errorMessage && <p id='text-input-error-desc-error' className='fr-error-text'>{errorMessage}</p>}
+    </div>
+  )
+}
+
+DateInput.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  errorMessage: PropTypes.string,
+  description: PropTypes.string,
+  isRequired: PropTypes.bool,
+  isDisable: PropTypes.bool,
+  onValueChange: PropTypes.func.isRequired
+}
+
+DateInput.defaultProps = {
+  value: '',
+  errorMessage: null,
+  description: null,
+  isRequired: false,
+  isDisable: false
+}
+
+export default DateInput

--- a/components/date-input.js
+++ b/components/date-input.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 
-const DateInput = ({label, value, name, errorMessage, description, isRequired, isDisable, onValueChange}) => {
+const DateInput = ({label, value, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
   const inputState = errorMessage ? 'error' : ''
 
   return (
@@ -15,7 +15,7 @@ const DateInput = ({label, value, name, errorMessage, description, isRequired, i
           value={value}
           name={name}
           required={isRequired}
-          disabled={isDisable}
+          disabled={isDisabled}
           onChange={e => onValueChange(e.target.value)}
         />
       </div>
@@ -32,7 +32,7 @@ DateInput.propTypes = {
   errorMessage: PropTypes.string,
   description: PropTypes.string,
   isRequired: PropTypes.bool,
-  isDisable: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   onValueChange: PropTypes.func.isRequired
 }
 
@@ -41,7 +41,7 @@ DateInput.defaultProps = {
   errorMessage: null,
   description: null,
   isRequired: false,
-  isDisable: false
+  isDisabled: false
 }
 
 export default DateInput

--- a/components/number-input.js
+++ b/components/number-input.js
@@ -1,7 +1,7 @@
 import {useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 
-const NumberInput = ({label, value, name, min, max, errorMessage, description, isRequired, onValueChange}) => {
+const NumberInput = ({label, value, name, min, max, placeholder, errorMessage, description, isRequired, isDisable, onValueChange}) => {
   const [minMaxError, setMinMaxError] = useState(null)
 
   const inputState = minMaxError || errorMessage ? 'error' : ''
@@ -39,6 +39,8 @@ const NumberInput = ({label, value, name, min, max, errorMessage, description, i
         value={value}
         min={min}
         max={max}
+        placeholder={placeholder}
+        disabled={isDisable}
         type='number'
         name={name}
         pattern='[0-9]+'
@@ -59,11 +61,13 @@ NumberInput.propTypes = {
   label: PropTypes.string.isRequired,
   value: PropTypes.string,
   name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
   min: PropTypes.number,
   max: PropTypes.number,
   errorMessage: PropTypes.string,
   description: PropTypes.string,
   isRequired: PropTypes.bool,
+  isDisable: PropTypes.bool,
   onValueChange: PropTypes.func.isRequired
 }
 
@@ -71,9 +75,11 @@ NumberInput.defaultProps = {
   value: '',
   min: null,
   max: null,
+  placeholder: null,
   errorMessage: null,
   description: null,
-  isRequired: false
+  isRequired: false,
+  isDisable: false
 }
 
 export default NumberInput

--- a/components/number-input.js
+++ b/components/number-input.js
@@ -1,7 +1,7 @@
 import {useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 
-const NumberInput = ({label, value, name, min, max, placeholder, errorMessage, description, isRequired, isDisable, onValueChange}) => {
+const NumberInput = ({label, value, min, max, placeholder, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
   const [minMaxError, setMinMaxError] = useState(null)
 
   const inputState = minMaxError || errorMessage ? 'error' : ''
@@ -40,7 +40,7 @@ const NumberInput = ({label, value, name, min, max, placeholder, errorMessage, d
         min={min}
         max={max}
         placeholder={placeholder}
-        disabled={isDisable}
+        disabled={isDisabled}
         type='number'
         name={name}
         pattern='[0-9]+'
@@ -67,7 +67,7 @@ NumberInput.propTypes = {
   errorMessage: PropTypes.string,
   description: PropTypes.string,
   isRequired: PropTypes.bool,
-  isDisable: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   onValueChange: PropTypes.func.isRequired
 }
 
@@ -79,7 +79,7 @@ NumberInput.defaultProps = {
   errorMessage: null,
   description: null,
   isRequired: false,
-  isDisable: false
+  isDisabled: false
 }
 
 export default NumberInput

--- a/components/number-input.js
+++ b/components/number-input.js
@@ -1,7 +1,7 @@
 import {useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 
-const NumberInput = ({label, value, min, max, placeholder, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
+const NumberInput = ({label, value, ariaLabel, min, max, placeholder, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
   const [minMaxError, setMinMaxError] = useState(null)
 
   const inputState = minMaxError || errorMessage ? 'error' : ''
@@ -26,14 +26,12 @@ const NumberInput = ({label, value, min, max, placeholder, errorMessage, descrip
   }, [value, min, max])
 
   return (
-    <div className={`fr-input-group fr-input-group--${inputState}`}>
-      <label
-        className='fr-label'
-        htmlFor={`text-input-${inputState}`}
-      >
+    <div className={`fr-input-group fr-input-group--${inputState}`} >
+      <label className='fr-label'>
         {label}
         {description && <span className='fr-hint-text fr-mb-2w'>{description}</span>}
       </label>
+
       <input
         required={isRequired}
         value={value}
@@ -41,8 +39,8 @@ const NumberInput = ({label, value, min, max, placeholder, errorMessage, descrip
         max={max}
         placeholder={placeholder}
         disabled={isDisabled}
+        aria-label={ariaLabel}
         type='number'
-        name={name}
         pattern='[0-9]+'
         className={`fr-input fr-input--${inputState}`}
         onChange={e => onValueChange(e.target.value)}
@@ -60,7 +58,7 @@ const NumberInput = ({label, value, min, max, placeholder, errorMessage, descrip
 NumberInput.propTypes = {
   label: PropTypes.string,
   value: PropTypes.string,
-  name: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string,
   placeholder: PropTypes.string,
   min: PropTypes.number,
   max: PropTypes.number,
@@ -74,6 +72,7 @@ NumberInput.propTypes = {
 NumberInput.defaultProps = {
   label: '',
   value: '',
+  ariaLabel: '',
   min: null,
   max: null,
   placeholder: null,

--- a/components/number-input.js
+++ b/components/number-input.js
@@ -58,7 +58,7 @@ const NumberInput = ({label, value, min, max, placeholder, errorMessage, descrip
 }
 
 NumberInput.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   value: PropTypes.string,
   name: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
@@ -72,6 +72,7 @@ NumberInput.propTypes = {
 }
 
 NumberInput.defaultProps = {
+  label: '',
   value: '',
   min: null,
   max: null,

--- a/components/number-input.js
+++ b/components/number-input.js
@@ -1,0 +1,79 @@
+import {useState, useEffect} from 'react'
+import PropTypes from 'prop-types'
+
+const NumberInput = ({label, value, name, min, max, errorMessage, description, isRequired, onValueChange}) => {
+  const [minMaxError, setMinMaxError] = useState(null)
+
+  const inputState = minMaxError || errorMessage ? 'error' : ''
+
+  useEffect(() => {
+    const hasMin = min === 0 || min
+    const hasMax = max === 0 || max
+
+    if ((hasMin && !hasMax) && value < min) {
+      setMinMaxError(`La valeur est inférieur à ${min}`)
+    }
+
+    if ((!hasMin && hasMax) && value > max) {
+      setMinMaxError(`La valeur est supérieur à ${max}`)
+    }
+
+    if ((hasMin && hasMax) && (value < min || value > max)) {
+      setMinMaxError(`La valeur doit être comprise entre ${min} et ${max}`)
+    } else {
+      setMinMaxError(null)
+    }
+  }, [value, min, max])
+
+  return (
+    <div className={`fr-input-group fr-input-group--${inputState}`}>
+      <label
+        className='fr-label'
+        htmlFor={`text-input-${inputState}`}
+      >
+        {label}
+        {description && <span className='fr-hint-text fr-mb-2w'>{description}</span>}
+      </label>
+      <input
+        required={isRequired}
+        value={value}
+        min={min}
+        max={max}
+        type='number'
+        name={name}
+        pattern='[0-9]+'
+        className={`fr-input fr-input--${inputState}`}
+        onChange={e => onValueChange(e.target.value)}
+      />
+
+      {(minMaxError || errorMessage) && (
+        <p id='text-input-error-desc-error' className='fr-error-text'>
+          {minMaxError || errorMessage}
+        </p>
+      )}
+    </div>
+  )
+}
+
+NumberInput.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  min: PropTypes.number,
+  max: PropTypes.number,
+  errorMessage: PropTypes.string,
+  description: PropTypes.string,
+  isRequired: PropTypes.bool,
+  onValueChange: PropTypes.func.isRequired
+}
+
+NumberInput.defaultProps = {
+  value: '',
+  min: null,
+  max: null,
+  errorMessage: null,
+  description: null,
+  isRequired: false
+}
+
+export default NumberInput

--- a/components/number-input.js
+++ b/components/number-input.js
@@ -11,11 +11,11 @@ const NumberInput = ({label, value, ariaLabel, min, max, placeholder, errorMessa
     const hasMax = max === 0 || max
 
     if ((hasMin && !hasMax) && value < min) {
-      setMinMaxError(`La valeur est inférieur à ${min}`)
+      setMinMaxError(`La valeur est inférieure à ${min}`)
     }
 
     if ((!hasMin && hasMax) && value > max) {
-      setMinMaxError(`La valeur est supérieur à ${max}`)
+      setMinMaxError(`La valeur est supérieure à ${max}`)
     }
 
     if ((hasMin && hasMax) && (value < min || value > max)) {

--- a/components/select-input.js
+++ b/components/select-input.js
@@ -5,7 +5,7 @@ const SelectInput = ({label, value, name, options, errorMessage, description, is
 
   return (
     <div className={`fr-select-group fr-select-group--${inputState}`}>
-      <label className='fr-label' htmlFor='select'>{label}</label>
+      <label className='fr-label'>{label}</label>
       {description && <span className='fr-hint-text fr-mb-2w'>{description}</span>}
 
       <select
@@ -13,7 +13,7 @@ const SelectInput = ({label, value, name, options, errorMessage, description, is
         name={name}
         className={`fr-select fr-select--${inputState}`}
         required={isRequired}
-        disabled={isDisable}
+        disabled={isDisabled}
         onChange={e => onValueChange(e.target.value)}
       >
         <option
@@ -24,11 +24,11 @@ const SelectInput = ({label, value, name, options, errorMessage, description, is
           Selectionnez une option
         </option>
 
-        {options.map(({value, label, isDisable}) => (
+        {options.map(({value, label, isDisabled}) => (
           <option
             key={value}
             value={value}
-            disabled={isDisable}
+            disabled={isDisabled}
           >
             {label}
           </option>
@@ -49,14 +49,14 @@ SelectInput.propTypes = {
   errorMessage: PropTypes.string,
   isRequired: PropTypes.bool,
   onValueChange: PropTypes.func.isRequired,
-  isDisable: PropTypes.bool
+  isDisabled: PropTypes.bool
 }
 
 SelectInput.defaultProps = {
   errorMessage: null,
   description: null,
   isRequired: false,
-  isDisable: false
+  isDisabled: false
 }
 
 export default SelectInput

--- a/components/select-input.js
+++ b/components/select-input.js
@@ -41,7 +41,7 @@ const SelectInput = ({label, value, name, options, errorMessage, description, is
 }
 
 SelectInput.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   value: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   options: PropTypes.array.isRequired,
@@ -53,6 +53,7 @@ SelectInput.propTypes = {
 }
 
 SelectInput.defaultProps = {
+  label: '',
   errorMessage: null,
   description: null,
   isRequired: false,

--- a/components/select-input.js
+++ b/components/select-input.js
@@ -42,7 +42,7 @@ const SelectInput = ({label, value, ariaLabel, options, errorMessage, descriptio
 
 SelectInput.propTypes = {
   label: PropTypes.string,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   ariaLabel: PropTypes.string,
   options: PropTypes.array.isRequired,
   description: PropTypes.string,
@@ -54,6 +54,7 @@ SelectInput.propTypes = {
 
 SelectInput.defaultProps = {
   label: '',
+  value: '',
   ariaLabel: '',
   errorMessage: null,
   description: null,

--- a/components/select-input.js
+++ b/components/select-input.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 
-const SelectInput = ({label, value, name, options, errorMessage, description, isRequired, isDisable, onValueChange}) => {
+const SelectInput = ({label, value, ariaLabel, options, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
   const inputState = errorMessage ? 'error' : ''
 
   return (
@@ -10,7 +10,7 @@ const SelectInput = ({label, value, name, options, errorMessage, description, is
 
       <select
         value={value}
-        name={name}
+        aria-label={ariaLabel}
         className={`fr-select fr-select--${inputState}`}
         required={isRequired}
         disabled={isDisabled}
@@ -43,7 +43,7 @@ const SelectInput = ({label, value, name, options, errorMessage, description, is
 SelectInput.propTypes = {
   label: PropTypes.string,
   value: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string,
   options: PropTypes.array.isRequired,
   description: PropTypes.string,
   errorMessage: PropTypes.string,
@@ -54,6 +54,7 @@ SelectInput.propTypes = {
 
 SelectInput.defaultProps = {
   label: '',
+  ariaLabel: '',
   errorMessage: null,
   description: null,
   isRequired: false,

--- a/components/select-input.js
+++ b/components/select-input.js
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types'
+
+const SelectInput = ({label, value, name, options, errorMessage, description, isRequired, isDisable, onValueChange}) => {
+  const inputState = errorMessage ? 'error' : ''
+
+  return (
+    <div className={`fr-select-group fr-select-group--${inputState}`}>
+      <label className='fr-label' htmlFor='select'>{label}</label>
+      {description && <span className='fr-hint-text fr-mb-2w'>{description}</span>}
+
+      <select
+        value={value}
+        name={name}
+        className={`fr-select fr-select--${inputState}`}
+        required={isRequired}
+        disabled={isDisable}
+        onChange={e => onValueChange(e.target.value)}
+      >
+        <option
+          disabled
+          hidden
+          value=''
+        >
+          Selectionnez une option
+        </option>
+
+        {options.map(({value, label, isDisable}) => (
+          <option
+            key={value}
+            value={value}
+            disabled={isDisable}
+          >
+            {label}
+          </option>
+        ))}
+      </select>
+
+      {errorMessage && <p className='fr-error-text'>{errorMessage}</p>}
+    </div>
+  )
+}
+
+SelectInput.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  options: PropTypes.array.isRequired,
+  description: PropTypes.string,
+  errorMessage: PropTypes.string,
+  isRequired: PropTypes.bool,
+  onValueChange: PropTypes.func.isRequired,
+  isDisable: PropTypes.bool
+}
+
+SelectInput.defaultProps = {
+  errorMessage: null,
+  description: null,
+  isRequired: false,
+  isDisable: false
+}
+
+export default SelectInput

--- a/components/text-input.js
+++ b/components/text-input.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types'
+
+const TextInput = ({label, value, name, placeholder, errorMessage, description, isRequired, isDisable, onValueChange}) => {
+  const inputState = errorMessage ? 'error' : ''
+
+  return (
+    <div className={`fr-input-group fr-input-group--${inputState}`}>
+      <label className='fr-label' htmlFor={`text-input-${inputState}`}>
+        {label}
+        {description && <span className='fr-hint-text fr-mb-2w'>{description}</span>}
+      </label>
+
+      <input
+        type='text'
+        required={isRequired}
+        className={`fr-input fr-input--${inputState}`}
+        value={value}
+        name={name}
+        placeholder={placeholder}
+        disabled={isDisable}
+        onChange={e => onValueChange(e.target.value)}
+      />
+
+      {errorMessage && <p id='text-input-error-desc-error' className='fr-error-text'>{errorMessage}</p>}
+    </div>
+  )
+}
+
+TextInput.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  errorMessage: PropTypes.string,
+  description: PropTypes.string,
+  isRequired: PropTypes.bool,
+  isDisable: PropTypes.bool,
+  onValueChange: PropTypes.func
+}
+
+TextInput.defaultProps = {
+  value: '',
+  placeholder: null,
+  errorMessage: null,
+  description: null,
+  isRequired: false,
+  isDisable: false
+}
+
+export default TextInput

--- a/components/text-input.js
+++ b/components/text-input.js
@@ -27,7 +27,7 @@ const TextInput = ({label, value, placeholder, errorMessage, description, isRequ
 }
 
 TextInput.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   value: PropTypes.string,
   name: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
@@ -39,6 +39,7 @@ TextInput.propTypes = {
 }
 
 TextInput.defaultProps = {
+  label: '',
   value: '',
   placeholder: null,
   errorMessage: null,

--- a/components/text-input.js
+++ b/components/text-input.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types'
 
-const TextInput = ({label, value, placeholder, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
+const TextInput = ({label, value, ariaLabel, placeholder, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
   const inputState = errorMessage ? 'error' : ''
 
   return (
     <div className={`fr-input-group fr-input-group--${inputState}`}>
-      <label className='fr-label' htmlFor={`text-input-${inputState}`}>
+      <label className='fr-label'>
         {label}
         {description && <span className='fr-hint-text fr-mb-2w'>{description}</span>}
       </label>
@@ -15,7 +15,7 @@ const TextInput = ({label, value, placeholder, errorMessage, description, isRequ
         required={isRequired}
         className={`fr-input fr-input--${inputState}`}
         value={value}
-        name={name}
+        aria-label={ariaLabel}
         placeholder={placeholder}
         disabled={isDisabled}
         onChange={e => onValueChange(e.target.value)}
@@ -29,7 +29,7 @@ const TextInput = ({label, value, placeholder, errorMessage, description, isRequ
 TextInput.propTypes = {
   label: PropTypes.string,
   value: PropTypes.string,
-  name: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string,
   placeholder: PropTypes.string,
   errorMessage: PropTypes.string,
   description: PropTypes.string,
@@ -41,6 +41,7 @@ TextInput.propTypes = {
 TextInput.defaultProps = {
   label: '',
   value: '',
+  ariaLabel: '',
   placeholder: null,
   errorMessage: null,
   description: null,

--- a/components/text-input.js
+++ b/components/text-input.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 
-const TextInput = ({label, value, name, placeholder, errorMessage, description, isRequired, isDisable, onValueChange}) => {
+const TextInput = ({label, value, placeholder, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
   const inputState = errorMessage ? 'error' : ''
 
   return (
@@ -17,7 +17,7 @@ const TextInput = ({label, value, name, placeholder, errorMessage, description, 
         value={value}
         name={name}
         placeholder={placeholder}
-        disabled={isDisable}
+        disabled={isDisabled}
         onChange={e => onValueChange(e.target.value)}
       />
 
@@ -34,7 +34,7 @@ TextInput.propTypes = {
   errorMessage: PropTypes.string,
   description: PropTypes.string,
   isRequired: PropTypes.bool,
-  isDisable: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   onValueChange: PropTypes.func
 }
 
@@ -44,7 +44,7 @@ TextInput.defaultProps = {
   errorMessage: null,
   description: null,
   isRequired: false,
-  isDisable: false
+  isDisabled: false
 }
 
 export default TextInput


### PR DESCRIPTION
Cette PR ajoute 4 composants réutilisables: 
Input de type `text`
Input de type `number`
Input de type `select`
Input de type `date`

### Type `text`
Ce composant accepte les props suivantes : 

- `label`: < string > Nom visible de l'input -  _required_
- `value`: < string > Valeur de l'input  (chaine de caractère vide par défaut)
- `name`: < string > Nom de l'input (accessibilité) - _required_
- `placeholder`: < string > Placeholder de l'input (vide par défault)
- `errorMessage`: < string > Message d'erreur passé par le composant parent
- `description`: < string > Affiche des indications supplémentaires concernant l'input
- `isRequired`: < boolean > Rend l'input `required`
- `isDisable`: < boolean > Rend l'input `disable`
- `onValueChange`: < function > Récupère et traite `event` - _required_

<img width="1374" alt="Capture d’écran 2023-02-07 à 14 11 12" src="https://user-images.githubusercontent.com/66621960/217255503-ce3aa518-d653-499e-9cd2-9f1b9a22a786.png">

### Type `number`
Ce composant accepte les props suivantes : 

- `label`: < string > Nom visible de l'input -  _required_
- `value`: < string > Valeur de l'input  (chaine de caractère vide par défaut)
- `name`: < string > Nom de l'input (accessibilité) - _required_
- `min`: < number > PropTypes.number,
- `max`: < number > PropTypes.number,
- `errorMessage`: < string > Message d'erreur passé par le composant parent
- `description`: < string > Affiche des indications supplémentaires concernant l'input
- `isRequired`: < boolean > Rend l'input `required`
- `isDisable`: < boolean > Rend l'input `disable`
- `onValueChange`: < function > Récupère et traite `event` - _required_

<img width="1161" alt="Capture d’écran 2023-02-07 à 14 51 47" src="https://user-images.githubusercontent.com/66621960/217263732-1589a21c-b066-4528-8364-b0d9bc17db5e.png">


### Type `select`
Ce composant accepte les props suivantes : 

- `label`: < string > Nom visible de l'input -  _required_
- `value`: < string > Valeur de l'input  (chaine de caractère vide par défaut)
- `name`: < string > Nom de l'input (accessibilité) - _required_
- `options`: < collection > Contient un tableau d'objets contenant une clé `label` et une clé `value`
- `errorMessage`: < string > Message d'erreur passé par le composant parent
- `description`: < string > Affiche des indications supplémentaires concernant l'input
- `isRequired`: < boolean > Rend l'input `required`
- `isDisable`: < boolean > Rend l'input `disable`
- `onValueChange`: < function > Récupère et traite `event` - _required_

<img width="1391" alt="Capture d’écran 2023-02-07 à 14 11 23" src="https://user-images.githubusercontent.com/66621960/217261267-5ab49d05-92a3-4742-a151-d25fd109199a.png">

### Type `date`
Ce composant accepte les props suivantes : 

- `label`: < string > Nom visible de l'input -  _required_
- `value`: < string > Valeur de l'input  (chaine de caractère vide par défaut)
- `name`: < string > Nom de l'input (accessibilité) - _required_
- `errorMessage`: < string > Message d'erreur passé par le composant parent
- `description`: < string > Affiche des indications supplémentaires concernant l'input
- `isRequired`: < boolean > Rend l'input `required`
- `isDisable`: < boolean > Rend l'input `disable`
- `onValueChange`: < function > Récupère et traite `event` - _required_


<img width="736" alt="Capture d’écran 2023-02-07 à 14 12 26" src="https://user-images.githubusercontent.com/66621960/217262056-80adce36-3374-4ad3-a43f-4706cb37311f.png">


