### PR TITLE
Amélioration du composant <Button />

### DIFF
--- a/components/button.js
+++ b/components/button.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types'
 import Link from 'next/link'
+
 import colors from '@/styles/colors.js'
 
-const Button = ({label, size, buttonStyle, href, isExternal, isWhite, children, ...props}) => {
+const Button = ({label, size, type, buttonStyle, isDisabled, icon, iconSide, href, isExternal, isWhite, children, ...props}) => {
   if (href) {
     return (
       <>
@@ -14,6 +15,7 @@ const Button = ({label, size, buttonStyle, href, isExternal, isWhite, children, 
             fr-btn fr-btn--${buttonStyle}
             fr-btn--${size}
             ${isWhite ? 'white-button' : ''}
+            ${icon ? `fr-btn--icon-${iconSide} fr-icon-${icon}` : ''}
           `}
             {...props}
             target='_blank'
@@ -28,6 +30,7 @@ const Button = ({label, size, buttonStyle, href, isExternal, isWhite, children, 
             fr-btn fr-btn--${buttonStyle}
             fr-btn--${size}
             ${isWhite ? 'white-button' : ''}
+            ${icon ? `fr-btn--icon-${iconSide} fr-icon-${icon}` : ''}
           `}
             >
               {children}
@@ -56,12 +59,14 @@ const Button = ({label, size, buttonStyle, href, isExternal, isWhite, children, 
 
   return (
     <button
-      type='submit'
+      type={type === 'submit' ? 'submit' : 'button'}
       aria-label={label}
+      disabled={isDisabled}
       className={`
         fr-btn fr-btn--${buttonStyle}
         fr-btn--${size}
         ${isWhite ? 'white-button' : ''}
+        ${icon ? `fr-btn--icon-${iconSide} fr-icon-${icon}` : ''}
       `}
       {...props}
     >
@@ -99,6 +104,17 @@ Button.propTypes = {
     'md',
     'lg'
   ]),
+  type: PropTypes.oneOf([
+    'button',
+    'submit'
+  ]),
+  isDisabled: PropTypes.bool,
+  icon: PropTypes.string,
+  iconSide: PropTypes.oneOf([
+    null,
+    'left',
+    'right'
+  ]),
   href: PropTypes.string,
   isExternal: PropTypes.bool,
   isWhite: PropTypes.bool,
@@ -108,6 +124,10 @@ Button.propTypes = {
 Button.defaultProps = {
   buttonStyle: null,
   size: 'md',
+  type: 'button',
+  isDisabled: false,
+  iconSide: 'left',
+  icon: null,
   href: null,
   isWhite: false,
   isExternal: false,


### PR DESCRIPTION
Le composant `<Button />` est modifié afin de :

- Donner la possibilité de définir un type `submit` || `button` (default)

- Donner la possibilité de désactiver l'interactivité du bouton.
<img width="237" alt="Capture d’écran 2023-02-15 à 15 05 26" src="https://user-images.githubusercontent.com/66621960/219049198-274922c0-a698-4a8e-83b5-8d42f388e494.png">

- Donner la possibilité d'ajouter une icône au bouton, sur la gauche ou sur la droite.

Ce composant accepte les nouvelles props suivantes :
`icon` : < string > icône remixicon (ex : `success-fill`)
`iconSide` : < string > position d'affichage de l'icône - `left` (default) || `right`
`isDisabled` : < book > activer ou désactiver le bouton

<img width="463" alt="Capture d’écran 2023-02-15 à 14 53 08" src="https://user-images.githubusercontent.com/66621960/219046500-52d1875f-82d0-455e-a7ad-13784d5bdb80.png">
