### PR TITLE
Correction du header en version mobile

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -1,81 +1,120 @@
+import {useState} from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 
-const Header = () => (
-  <header role='banner' className='fr-header'>
-    <div className='fr-header__body'>
-      <div className='fr-container'>
-        <div className='fr-header__body-row'>
-          <div className='header-redirect fr-header__brand fr-enlarge-link'>
-            <div className='fr-header__brand-top'>
+const Header = () => {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const handleMenuOpen = () => setIsMobileMenuOpen(!isMobileMenuOpen)
+
+  return (
+    <header role='banner' className='fr-header'>
+      <div className='fr-header__body'>
+        <div className='fr-container'>
+          <div className='fr-header__body-row'>
+            <div className='header-redirect fr-header__brand fr-enlarge-link'>
+              <div className='fr-header__brand-top'>
+                <Link href='/'>
+                  <div className='fr-header__logo'>
+                    <p className='fr-logo'>
+                      RÉPUBLIQUE<br />FRANÇAISE
+                    </p>
+                  </div>
+                </Link>
+                <div className='fr-header__navbar'>
+                  <button type='button' className='fr-btn--menu fr-btn' onClick={handleMenuOpen}>
+                    Menu
+                  </button>
+                </div>
+              </div>
               <Link href='/'>
-                <div className='fr-header__logo'>
-                  <p className='fr-logo'>
-                    RÉPUBLIQUE<br />FRANÇAISE
-                  </p>
+                <div className='fr-header__service'>
+                  <Image
+                    src='/images/logos/logo-pcrsgouvfr.png'
+                    height='25'
+                    width='205'
+                    alt='pcrs.beta.gouv.fr'
+                  />
                 </div>
               </Link>
-              <div className='fr-header__navbar'>
-                <button type='button' className='fr-btn--menu fr-btn' data-fr-opened='false' aria-controls='modal-499' aria-haspopup='menu' id='button-500' title='Menu'>
-                  Menu
-                </button>
-              </div>
             </div>
-            <Link href='/'>
-              <div className='fr-header__service'>
-                <Image
-                  src='/images/logos/logo-pcrsgouvfr.png'
-                  height='25'
-                  width='205'
-                  alt='pcrs.beta.gouv.fr'
-                />
-              </div>
-            </Link>
-          </div>
 
-          <div className='fr-header__tools'>
-            <div className='fr-header__tools-links'>
-              <ul className='fr-btns-group'>
-                <li>
-                  <Link legacyBehavior href='/suivi-pcrs'>
-                    <a className='fr-btn fr-icon-road-map-line'>
-                      Suivi géographique
+            <div className='fr-header__tools'>
+              <div className='fr-header__tools-links'>
+                <ul className='fr-btns-group'>
+                  <li>
+                    <Link legacyBehavior href='/suivi-pcrs'>
+                      <a className='fr-btn fr-icon-road-map-line'>
+                        Suivi géographique
+                      </a>
+                    </Link>
+                  </li>
+                  <li>
+                    <Link legacyBehavior href='/blog'>
+                      <a className='fr-btn fr-icon-article-line'>
+                        Blog du PCRS
+                      </a>
+                    </Link>
+                  </li>
+                  <li>
+                    <a
+                      href='https://docs.pcrs.beta.gouv.fr/'
+                      className='fr-btn fr-icon-book-2-line'
+                      target='_blank'
+                      rel='noreferrer'
+                    >
+                      Espace documentaire
                     </a>
-                  </Link>
-                </li>
-                <li>
-                  <Link legacyBehavior href='/blog'>
-                    <a className='fr-btn fr-icon-article-line'>
-                      Blog du PCRS
-                    </a>
-                  </Link>
-                </li>
-                <li>
-                  <a
-                    href='https://docs.pcrs.beta.gouv.fr/'
-                    className='fr-btn fr-icon-book-2-line'
-                    target='_blank'
-                    rel='noreferrer'
-                  >
-                    Espace documentaire
-                  </a>
-                </li>
-              </ul>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div className='fr-header__menu fr-modal' id='modal-499' aria-labelledby='button-500'>
-      <div className='fr-container'>
-        <button type='button' className='fr-btn--close fr-btn' aria-controls='modal-499' title='Fermer'>
-          Fermer
-        </button>
-        <div className='fr-header__menu-links' />
-      </div>
-    </div>
 
-    <style jsx>{`
+      {isMobileMenuOpen && (
+        <div className='custom-mobile-menu'>
+          <button
+            type='button'
+            className='fr-btn--close fr-btn'
+            title='Fermer'
+            onClick={handleMenuOpen}
+          >
+            Fermer
+          </button>
+          <div className='fr-header__menu-links'>
+            <ul className='fr-btns-group'>
+              <li>
+                <Link legacyBehavior href='/suivi-pcrs'>
+                  <a className='fr-btn fr-icon-road-map-line'>
+                    Suivi géographique
+                  </a>
+                </Link>
+              </li>
+              <li>
+                <Link legacyBehavior href='/blog'>
+                  <a className='fr-btn fr-icon-article-line'>
+                    Blog du PCRS
+                  </a>
+                </Link>
+              </li>
+              <li>
+                <a
+                  href='https://docs.pcrs.beta.gouv.fr/'
+                  className='fr-btn fr-icon-book-2-line'
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  Espace documentaire
+                </a>
+              </li>
+            </ul>
+          </div>
+
+        </div>
+      )}
+
+      <style jsx>{`
       .header-redirect {
         cursor: pointer;
       }
@@ -83,8 +122,20 @@ const Header = () => (
       a {
         width: 100%;
       }
+
+      .custom-mobile-menu {
+        z-index: 9999;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: white;
+        padding: 1.5em;
+      }
     `}</style>
-  </header>
-)
+    </header>
+  )
+}
 
 export default Header

--- a/components/header.js
+++ b/components/header.js
@@ -6,20 +6,22 @@ const Header = () => (
     <div className='fr-header__body'>
       <div className='fr-container'>
         <div className='fr-header__body-row'>
-          <Link legacyBehavior href='/'>
-            <div className='header-redirect fr-header__brand fr-enlarge-link'>
-              <div className='fr-header__brand-top'>
+          <div className='header-redirect fr-header__brand fr-enlarge-link'>
+            <div className='fr-header__brand-top'>
+              <Link href='/'>
                 <div className='fr-header__logo'>
                   <p className='fr-logo'>
                     RÉPUBLIQUE<br />FRANÇAISE
                   </p>
                 </div>
-                <div className='fr-header__navbar'>
-                  <button type='button' className='fr-btn--menu fr-btn' data-fr-opened='false' aria-controls='modal-499' aria-haspopup='menu' id='button-500' title='Menu'>
-                    Menu
-                  </button>
-                </div>
+              </Link>
+              <div className='fr-header__navbar'>
+                <button type='button' className='fr-btn--menu fr-btn' data-fr-opened='false' aria-controls='modal-499' aria-haspopup='menu' id='button-500' title='Menu'>
+                  Menu
+                </button>
               </div>
+            </div>
+            <Link href='/'>
               <div className='fr-header__service'>
                 <Image
                   src='/images/logos/logo-pcrsgouvfr.png'
@@ -28,8 +30,9 @@ const Header = () => (
                   alt='pcrs.beta.gouv.fr'
                 />
               </div>
-            </div>
-          </Link>
+            </Link>
+          </div>
+
           <div className='fr-header__tools'>
             <div className='fr-header__tools-links'>
               <ul className='fr-btns-group'>


### PR DESCRIPTION
L'intégration de la barre de navigation dans le header a révélé un souci d'affichage du menu lors du passage en version mobile. 
Le bouton permettant l'ouverture du menu n'est pas trigger au clic dû à un souci d'intégration de l'API Javascript du DSFR dans un projet Next.js.

L'ouverture de ce menu est donc géré "manuellement" grâce une state permettant de déclencher l'ouverture/fermeture de la modale. Le css reproduit le plus fidèlement possible celui du DSFR.

<img width="707" alt="Capture d’écran 2023-02-24 à 14 44 25" src="https://user-images.githubusercontent.com/66621960/221193865-66c7f239-c298-4579-85ee-264126f21b42.png">
