### PR TITLE
Corrige le problème de bouton de la sidebar sous Safari + problèmes mineurs

### DIFF
--- a/components/map-sidebar/contact.js
+++ b/components/map-sidebar/contact.js
@@ -11,7 +11,7 @@ const Contact = ({name, phone, mail}) => (
     </div>
     <div className='contact-infos fr-pl-2w'>
       <div className={name ? '' : 'no-data'} aria-label='Nom du contact de référence'>
-        {`${name || 'non-renseigné'}`}
+        {`${name || 'non renseigné'}`}
       </div>
 
       <a

--- a/components/map-sidebar/pcrs-infos.js
+++ b/components/map-sidebar/pcrs-infos.js
@@ -102,6 +102,9 @@ const PcrsInfos = ({nature, regime, livrable, diffusion, licence, acteurs}) => {
               <button
                 type='button'
                 className='fr-btn--tertiary-no-outline'
+                style={{
+                  visibility: isActorsShow ? 'hidden' : 'visible'
+                }}
                 onClick={() => setIsActorsShow(true)}
               >
                 ...afficher la liste des acteurs

--- a/layouts/map.js
+++ b/layouts/map.js
@@ -107,17 +107,21 @@ export const Desktop = ({handleClick, projet, isOpen, setIsOpen}) => (
     }}
   >
     {projet && (
-      <div
-        style={{
-          minWidth: isOpen ? '460px' : '5px',
-          maxWidth: '460px',
-          boxShadow: '0px 0px 5px grey',
-          height: 'calc(100vh - 117px)',
-          zIndex: 1,
-          overflow: 'auto',
-          overflowX: 'hidden'
-        }}
-      >
+      <>
+        <div
+          style={{
+            minWidth: isOpen ? '460px' : '5px',
+            maxWidth: '460px',
+            boxShadow: '0px 0px 5px grey',
+            height: 'calc(100vh - 117px)',
+            overflow: 'auto',
+            overflowX: 'hidden'
+          }}
+        >
+          {isOpen && (
+            <MapSidebar projet={projet} />
+          )}
+        </div>
         <button
           type='button'
           className={`fr-icon-arrow-${isOpen ? 'left' : 'right'}-s-line`}
@@ -131,18 +135,18 @@ export const Desktop = ({handleClick, projet, isOpen, setIsOpen}) => (
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'center',
+            alignItems: 'center',
             borderRadius: '0 5px 5px 0',
-            boxShadow: '2px 2px 5px grey'
+            boxShadow: '2px 2px 5px grey',
+            zIndex: 3
           }}
           onClick={() => setIsOpen(!isOpen)}
         />
-        {isOpen && (
-          <MapSidebar projet={projet} />
-        )}
-      </div>
+      </>
     )}
+
     <div style={{width: '100%', height: 'calc(100vh - 117px)'}}>
-      <Map handleClick={handleClick} />
+      <Map style={{pointerEvents: 'all'}} handleClick={handleClick} />
     </div>
   </div>
 )


### PR DESCRIPTION
Cette PR corrige un problème de bouton sur Safari, ainsi que deux problèmes mineurs.

- Sous Safari, le bouton permettant d'ouvrir / fermer le panneau latéral ne s'affichait pas
- Le message "Afficher la liste des acteurs" restait affiché lorsque le panneau était ouvert
- Suppression du tiret sur "non renseigné"
