### PR TITLE
Rejet des dates de type YY-MM-DD

### DIFF
--- a/lib/__tests__/projets-validator.js
+++ b/lib/__tests__/projets-validator.js
@@ -95,7 +95,8 @@ test('Joi/validateJoiDate : not valid', t => {
     '2020',
     'foo',
     '2020-40-40',
-    '2020-01-01T10:00:00.000Z'
+    '2020-01-01T10:00:00.000Z',
+    '10-10-10'
   ]
 
   for (const notValidDate of notValidDates) {

--- a/lib/projets-validator.js
+++ b/lib/projets-validator.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 
 import Joi from 'joi'
-import {parse, isValid} from 'date-fns'
+import {isValid} from 'date-fns'
 import {validatePayload} from '../server/util/payload.js'
 import {getTerritoire} from '../lib/territoires.js'
 
@@ -19,7 +19,11 @@ function validatePerimetre(perimetre) {
 }
 
 export function validateJoiDate(date, helpers) {
-  const parsedDate = parse(date, 'yyyy-MM-dd', new Date())
+  if (!date || typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return helpers.message('Date invalide')
+  }
+
+  const parsedDate = new Date(date)
 
   if (!isValid(parsedDate)) {
     return helpers.message('Date invalide')

--- a/lib/projets-validator.js
+++ b/lib/projets-validator.js
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 
 import Joi from 'joi'
-import {isValid} from 'date-fns'
 import {validatePayload} from '../server/util/payload.js'
 import {getTerritoire} from '../lib/territoires.js'
 
@@ -25,7 +24,7 @@ export function validateJoiDate(date, helpers) {
 
   const parsedDate = new Date(date)
 
-  if (!isValid(parsedDate)) {
+  if (parsedDate.toString() === 'Invalid Date') {
     return helpers.message('Date invalide')
   }
 


### PR DESCRIPTION
En raison d'une anomalie avec la fonction `parse` de `date-fns` le pattern `YYYY-MM-DD` n'était pas strictement respecté.
En effet la date `10-10-10` était acceptée.

Cette PR ajout un cas de test litigieux et reprend l'implémentation de la validation des dates simples.

https://github.com/date-fns/date-fns/issues/3364