### PR TITLE
Mise à jour de la validation et des tests

### DIFF
--- a/lib/__tests__/projets-validator.js
+++ b/lib/__tests__/projets-validator.js
@@ -3,7 +3,7 @@
 
 import test from 'ava'
 import Joi from 'joi'
-import {validateCreation, validateChanges, validateJoiDate} from '../projets-validator.js'
+import {validateCreation, validateChanges, validateJoiDate, validatePerimetre} from '../projets-validator.js'
 
 const validProjet = {
   nom: 'Projet Valide',
@@ -68,6 +68,43 @@ const invalidProjet = {
   subventions: [{nom: 'Participation feder', ntr: 'feder'}]
 }
 
+// Test validatePerimetre
+
+test('Valid perimetre, departement', t => {
+  t.is(validatePerimetre('departement:55'), 'departement:55')
+})
+
+test('Invalid perimetre, departement', t => {
+  const error = t.throws(() => {
+    validatePerimetre('departement:666')
+  }, {instanceOf: Error})
+
+  t.is(error.message, 'Territory not found: departement:666')
+})
+
+test('Valid perimetre, epci', t => {
+  t.is(validatePerimetre('epci:200038990'), 'epci:200038990')
+})
+
+test('Invalid perimetre, epci', t => {
+  const error = t.throws(() => {
+    validatePerimetre('epci:666')
+  }, {instanceOf: Error})
+
+  t.is(error.message, 'Territory not found: epci:666')
+})
+
+test('Valid perimetre, commune', t => {
+  t.is(validatePerimetre('commune:55500'), 'commune:55500')
+})
+
+test('Invalid perimetre, commune', t => {
+  const error = t.throws(() => {
+    validatePerimetre('commune:666')
+  }, {instanceOf: Error})
+
+  t.is(error.message, 'Territory not found: commune:666')
+})
 test('Create valid projet', t => {
   t.notThrows(() => validateCreation(validProjet))
 })

--- a/lib/__tests__/projets-validator.js
+++ b/lib/__tests__/projets-validator.js
@@ -105,12 +105,33 @@ test('Invalid perimetre, commune', t => {
 
   t.is(error.message, 'Territory not found: commune:666')
 })
+
+// Test validateCreation
+
 test('Create valid projet', t => {
   t.notThrows(() => validateCreation(validProjet))
 })
 
 test('Create invalid projet', t => {
-  t.throws(() => validateCreation(invalidProjet))
+  const error = t.throws(() => {
+    validateCreation(invalidProjet)
+  }, {instanceOf: Error})
+
+  t.is(error.validation.length, 14)
+  t.is(error.validation[0].message, '"nom" is required')
+  t.is(error.validation[1].message, '"regime" must be one of [production, maj]')
+  t.is(error.validation[2].message, '"nature" must be one of [vecteur, raster, mixte]')
+  t.is(error.validation[3].message, '"livrables[0].nature" must be one of [geotiff, jpeg2000, gml]')
+  t.is(error.validation[4].message, '"livrables[0].licence" must be one of [ouvert_lo, ouvert_odbl, ferme]')
+  t.is(error.validation[5].message, '"livrables[0].diffusion" must be one of [telechargement, flux]')
+  t.is(error.validation[6].message, '"livrables[0].avancement" must be a number')
+  t.is(error.validation[7].message, '"acteurs[0].telephone" with value "+33324594528333" fails to match the required pattern: /^((\\+)33|0|0033)[1-9](\\d{2}){4}$/')
+  t.is(error.validation[8].message, '"acteurs[0].role" must be one of [aplc, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
+  t.is(error.validation[9].message, '"acteurs[1].role" must be one of [aplc, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
+  t.is(error.validation[10].message, '"perimetres[0]" failed custom validation because Territory not found: departement:00')
+  t.is(error.validation[11].message, 'Date invalide')
+  t.is(error.validation[12].message, '"subventions[0].nature" is required')
+  t.is(error.validation[13].message, '"subventions[0].ntr" is not allowed')
 })
 
 test('Update valid projet', t => {

--- a/lib/__tests__/projets-validator.js
+++ b/lib/__tests__/projets-validator.js
@@ -14,7 +14,10 @@ const validProjet = {
       nom: 'Images raster',
       nature: 'geotiff',
       diffusion: 'flux',
-      licence: 'ouvert_lo'
+      licence: 'ouvert_lo',
+      avancement: 18,
+      crs: 'ok',
+      compression: null
     }
   ],
   acteurs: [
@@ -36,7 +39,6 @@ const validProjet = {
 }
 
 const invalidProjet = {
-  nom: 'Projet Pas Valide',
   regime: 'productio',
   nature: 'rastèr',
   livrables: [
@@ -44,7 +46,8 @@ const invalidProjet = {
       nom: 'Images raster',
       nature: 'geotouff',
       diffusion: 'flox',
-      licence: 'ouverte_lo'
+      licence: 'ouverte_lo',
+      avancement: '12'
     }
   ],
   acteurs: [

--- a/lib/__tests__/projets-validator.js
+++ b/lib/__tests__/projets-validator.js
@@ -134,13 +134,32 @@ test('Create invalid projet', t => {
   t.is(error.validation[13].message, '"subventions[0].ntr" is not allowed')
 })
 
+// Test validateChanges
+
 test('Update valid projet', t => {
   t.notThrows(() => validateChanges(validProjet))
 })
 
 test('Update invalid projet', t => {
-  t.throws(() => validateChanges(invalidProjet))
+  const error = t.throws(() => {
+    validateChanges(invalidProjet)
+  }, {instanceOf: Error})
+
+  t.is(error.validation.length, 11)
+  t.is(error.validation[0].message, '"regime" must be one of [production, maj]')
+  t.is(error.validation[1].message, '"nature" must be one of [vecteur, raster, mixte]')
+  t.is(error.validation[2].message, '"livrables[0].nature" must be one of [geotiff, jpeg2000, gml]')
+  t.is(error.validation[3].message, '"livrables[0].licence" must be one of [ouvert_lo, ouvert_odbl, ferme]')
+  t.is(error.validation[4].message, '"livrables[0].diffusion" must be one of [telechargement, flux, null]')
+  t.is(error.validation[5].message, '"livrables[0].avancement" must be a number')
+  t.is(error.validation[6].message, '"acteurs[0].telephone" with value "+33324594528333" fails to match the required pattern: /^((\\+)33|0|0033)[1-9](\\d{2}){4}$/')
+  t.is(error.validation[7].message, '"acteurs[0].role" must be one of [aplc, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
+  t.is(error.validation[8].message, '"acteurs[1].role" must be one of [aplc, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
+  t.is(error.validation[9].message, 'Date invalide')
+  t.is(error.validation[10].message, '"subventions[0].ntr" is not allowed')
 })
+
+// Test validateJoiDate
 
 test('Joi/validateJoiDate : valid', t => {
   const result = Joi.custom(validateJoiDate).validate('2020-01-01')

--- a/lib/projets-validator.js
+++ b/lib/projets-validator.js
@@ -77,7 +77,7 @@ const livrablesSchemaCreation = Joi.object().keys({
     'flux'
   ),
   crs: Joi.string(),
-  avancement: Joi.string(),
+  avancement: Joi.number().allow(null),
   compression: Joi.string()
 })
 
@@ -158,7 +158,7 @@ const livrablesSchemaUpdate = Joi.object().keys({
     'flux'
   ),
   crs: Joi.string(),
-  avancement: Joi.string(),
+  avancement: Joi.number().allow(null),
   compression: Joi.string()
 })
 

--- a/lib/projets-validator.js
+++ b/lib/projets-validator.js
@@ -200,5 +200,5 @@ function validateChanges(changes) {
   validatePayload(changes, schemaUpdate)
 }
 
-export {validateCreation, validateChanges}
+export {validateCreation, validateChanges, validatePerimetre}
 

--- a/lib/projets-validator.js
+++ b/lib/projets-validator.js
@@ -33,10 +33,10 @@ export function validateJoiDate(date, helpers) {
 
 const acteursSchemaCreation = Joi.object().keys({
   siren: Joi.number().required(),
-  nom: Joi.string(),
-  interlocuteur: Joi.string(),
-  mail: Joi.string().email(),
-  telephone: Joi.string().pattern(/^((\+)33|0|0033)[1-9](\d{2}){4}$/),
+  nom: Joi.string().allow(null),
+  interlocuteur: Joi.string().allow(null),
+  mail: Joi.string().email().allow(null),
+  telephone: Joi.string().pattern(/^((\+)33|0|0033)[1-9](\d{2}){4}$/).allow(null),
   role: Joi.valid(
     'aplc',
     'financeur',
@@ -45,8 +45,8 @@ const acteursSchemaCreation = Joi.object().keys({
     'presta_lidar',
     'controleur'
   ).required(),
-  finance_part_perc: Joi.number(),
-  finance_part_euro: Joi.number()
+  finance_part_perc: Joi.number().allow(null),
+  finance_part_euro: Joi.number().allow(null)
 })
 
 const etapesSchemaCreation = Joi.object().keys({
@@ -76,9 +76,9 @@ const livrablesSchemaCreation = Joi.object().keys({
     'telechargement',
     'flux'
   ),
-  crs: Joi.string(),
+  crs: Joi.string().allow(null),
   avancement: Joi.number().allow(null),
-  compression: Joi.string()
+  compression: Joi.string().allow(null)
 })
 
 const subventionsSchemaCreation = Joi.object().keys({
@@ -88,7 +88,7 @@ const subventionsSchemaCreation = Joi.object().keys({
     'cepr',
     'detr'
   ).required(),
-  montant: Joi.number(),
+  montant: Joi.number().allow(null),
   echeance: Joi.custom(validateJoiDate).allow(null)
 })
 
@@ -114,10 +114,10 @@ const schemaCreation = Joi.object({
 
 const acteursSchemaUpdate = Joi.object().keys({
   siren: Joi.number(),
-  nom: Joi.string(),
-  interlocuteur: Joi.string(),
-  mail: Joi.string().email(),
-  telephone: Joi.string().pattern(/^((\+)33|0|0033)[1-9](\d{2}){4}$/),
+  nom: Joi.string().allow(null),
+  interlocuteur: Joi.string().allow(null),
+  mail: Joi.string().email().allow(null),
+  telephone: Joi.string().pattern(/^((\+)33|0|0033)[1-9](\d{2}){4}$/).allow(null),
   role: Joi.valid(
     'aplc',
     'financeur',
@@ -126,8 +126,8 @@ const acteursSchemaUpdate = Joi.object().keys({
     'presta_lidar',
     'controleur'
   ),
-  finance_part_perc: Joi.number(),
-  finance_part_euro: Joi.number()
+  finance_part_perc: Joi.number().allow(null),
+  finance_part_euro: Joi.number().allow(null)
 })
 
 const etapesSchemaUpdate = Joi.object().keys({
@@ -156,10 +156,10 @@ const livrablesSchemaUpdate = Joi.object().keys({
   diffusion: Joi.valid(
     'telechargement',
     'flux'
-  ),
-  crs: Joi.string(),
+  ).allow(null),
+  crs: Joi.string().allow(null),
   avancement: Joi.number().allow(null),
-  compression: Joi.string()
+  compression: Joi.string().allow(null)
 })
 
 const subventionsSchemaUpdate = Joi.object().keys({
@@ -169,7 +169,7 @@ const subventionsSchemaUpdate = Joi.object().keys({
     'cepr',
     'detr'
   ),
-  montant: Joi.number(),
+  montant: Joi.number().allow(null),
   echeance: Joi.custom(validateJoiDate).allow(null)
 })
 


### PR DESCRIPTION
Cette PR mets à jour le schéma de validation des projets afin de pouvoir ajouter le formulaire de création de projet.

- Mise à jour du champ `avancement`
- Ajout de la possibilité d’envoyer une valeur `null` sur les champs qui ne sont pas obligatoires
- Mise à jour des tests : 
  - Modification du schéma invalide
  - Ajout de tests pour la fonction `validatePerimetre` 
  - Mise à jour des tests pour la fonction `validateCreation`
  - Mise à jour des tests pour la fonction `validateChanges`