### PR TITLE
Ajout du script de migration des projets yaml vers la base de donnée

### DIFF
--- a/data/herault-montpellier-2022-vecteur.yaml
+++ b/data/herault-montpellier-2022-vecteur.yaml
@@ -1,4 +1,4 @@
-nom: Métropole de Montpellier 2022
+nom: Métropole de Montpellier 2022 - vecteur
 regime: production
 nature: vecteur
 

--- a/scripts/migration-projets.js
+++ b/scripts/migration-projets.js
@@ -7,38 +7,28 @@ import * as dotenv from 'dotenv'
 
 dotenv.config()
 
-import process from 'node:process'
 import path from 'node:path'
 import {readdir, readFile} from 'node:fs/promises'
 import yaml, {JSON_SCHEMA} from 'js-yaml'
 import mongo from '../server/util/mongo.js'
 import {createProjet} from '../server/projets.js'
 
-async function projetsMigration() {
-  const filesList = await readdir('./data')
+const filesList = await readdir('./data')
 
-  await mongo.connect()
+await mongo.connect()
 
-  for (const fileName of filesList) {
-    if (fileName.endsWith('.yaml') && fileName !== 'projet-exemple.yaml') {
-      const filePath = path.join('./data', fileName)
-      const projet = yaml.load(await readFile(filePath), {schema: JSON_SCHEMA})
+for (const fileName of filesList) {
+  if (fileName.endsWith('.yaml') && fileName !== 'projet-exemple.yaml') {
+    const filePath = path.join('./data', fileName)
+    const projet = yaml.load(await readFile(filePath), {schema: JSON_SCHEMA})
 
-      console.log('Insertion du projet ->', projet.nom)
+    console.log('Insertion du projet ->', projet.nom)
 
-      await createProjet(projet)
-    }
+    await createProjet(projet)
   }
-
-  console.log('\nLes projets ont bien été importés dans la base 🎉\n')
-
-  mongo.disconnect()
 }
 
-try {
-  await projetsMigration()
-} catch (error) {
-  console.log(error)
-  process.exit(1)
-}
+console.log('\nLes projets ont bien été importés dans la base 🎉\n')
+
+mongo.disconnect()
 

--- a/scripts/migration-projets.js
+++ b/scripts/migration-projets.js
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
+/* eslint-disable import/order */
+/* eslint-disable import/first */
 /* eslint-disable no-await-in-loop */
+
+import * as dotenv from 'dotenv'
+
+dotenv.config()
 
 import process from 'node:process'
 import path from 'node:path'

--- a/scripts/migration-projets.js
+++ b/scripts/migration-projets.js
@@ -35,8 +35,10 @@ async function projetsMigration() {
   mongo.disconnect()
 }
 
-projetsMigration().catch(error => {
-  console.error(error)
+try {
+  await projetsMigration()
+} catch (error) {
+  console.log(error)
   process.exit(1)
-})
+}
 

--- a/scripts/migration-projets.js
+++ b/scripts/migration-projets.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/* eslint-disable no-await-in-loop */
+
+import process from 'node:process'
+import path from 'node:path'
+import {readdir, readFile} from 'node:fs/promises'
+import yaml, {JSON_SCHEMA} from 'js-yaml'
+import mongo from '../server/util/mongo.js'
+import {createProjet} from '../server/projets.js'
+
+async function projetsMigration() {
+  const filesList = await readdir('./data')
+
+  await mongo.connect()
+
+  for (const fileName of filesList) {
+    if (fileName.endsWith('.yaml') && fileName !== 'projet-exemple.yaml') {
+      const filePath = path.join('./data', fileName)
+      const projet = yaml.load(await readFile(filePath), {schema: JSON_SCHEMA})
+
+      console.log('Insertion du projet ->', projet.nom)
+
+      await createProjet(projet)
+    }
+  }
+
+  console.log('\nLes projets ont bien été importés dans la base 🎉\n')
+
+  mongo.disconnect()
+}
+
+projetsMigration().catch(error => {
+  console.error(error)
+  process.exit(1)
+})
+


### PR DESCRIPTION
Cette PR ajoute un script de migration qui permet de transférer les fichiers projets au format YAML vers la base de données MongoDB.

- Ajout du script de migration
- Correction d’un nom de projet en doublon
