### PR TITLE
Fix contact name overflow

### DIFF
--- a/components/map-sidebar/contact.js
+++ b/components/map-sidebar/contact.js
@@ -3,62 +3,46 @@ import PropTypes from 'prop-types'
 import colors from '@/styles/colors.js'
 
 const Contact = ({name, phone, mail}) => (
-  <div className='contact'>
-    <div className='contact-icons fr-pr-1w'>
-      <span aria-disabled className='fr-icon-user-fill' aria-hidden='true' />
-      <span aria-disabled className='fr-icon-phone-fill' aria-hidden='true' />
-      <span aria-disabled className='fr-icon-mail-fill' aria-hidden='true' />
-    </div>
-    <div className='contact-infos fr-pl-2w'>
-      <div className={name ? '' : 'no-data'} aria-label='Nom du contact de référence'>
-        {`${name || 'non renseigné'}`}
+  <div className='contact fr-container'>
+    <div className='contact-info fr-grid-row'>
+      <span aria-disabled className='fr-icon-user-fill fr-col-1 fr-mr-1w' aria-hidden='true' />
+      <div className='fr-col-10 contact-data fr-pl-2w fr-ml-1w'>
+        <div aria-label='Nom du contact de référence'>
+          {`${name || 'non renseigné'}`}
+        </div>
       </div>
-
-      <a
-        href={`tel:${phone}`}
-        className={phone ? '' : 'no-data'}
-        aria-label='Numéro de téléphone du contact de référence'
-      >
-        {`${phone || 'non-renseigné'}`}
-      </a>
-
-      <a
-        href={`mailto:${mail}`}
-        className={mail ? '' : 'no-data'}
-        target='_self'
-        aria-label='Email du contact de référence'
-      >
-        {`${mail || 'non renseigné'}`}
-      </a>
     </div>
+
+    <div className='contact-info fr-grid-row fr-grid-row--middle'>
+      <span aria-disabled className='fr-icon-phone-fill fr-col-1 fr-mr-1w fr-py-2w' aria-hidden='true' />
+      <div className='fr-col-10 contact-data fr-py-2w fr-pl-2w fr-ml-1w'>
+        <a href={`tel:${phone}`} aria-label='Numéro de téléphone du contact de référence'>
+          {`${phone || 'non-renseigné'}`}
+        </a>
+      </div>
+    </div>
+
+    <div className='contact-info fr-grid-row fr-grid-row--middle'>
+      <span aria-disabled className='fr-icon-mail-fill fr-col-1 fr-mr-1w' aria-hidden='true' />
+      <div className='fr-col-10 contact-data fr-pl-2w fr-ml-1w'>
+        <a
+          href={`mailto:${mail}`}
+          target='_self'
+          aria-label='Email du contact de référence'
+        >
+          {`${mail || 'non renseigné'}`}
+        </a>
+      </div>
+    </div>
+    <div />
 
     <style jsx>{`
       .contact {
-        display: grid;
-        grid-template-columns: 40px 1fr;
-        align-items: center;
         color: ${colors.blueFranceSun113};
       }
 
-      .contact-icons {
-        border-right: 3px solid ${colors.blueFrance850};
-      }
-
-      .contact-icons, .contact-infos {
-        display: grid;
-        grid-template-rows: 30px;
-        gap: 10px
-      }
-
-      .contact a {
-        width: fit-content;
-      }
-
-      .no-data {
-        pointer-events: none;
-        font-style: italic;
-        text-decoration: none;
-        color: ${colors.grey200};
+      .contact-data {
+        border-left: 3px solid ${colors.blueFrance850};
       }
     `}</style>
   </div>


### PR DESCRIPTION
Correction de l'affichage du nom du contact lorsque sa longueur force le retour à la ligne.

### **AVANT**
![avant](https://user-images.githubusercontent.com/66621960/226408210-172ee479-54af-4102-9463-fd373d7beda2.png)

### **APRÈS**
<img width="459" alt="Capture d’écran 2023-03-20 à 17 40 04" src="https://user-images.githubusercontent.com/66621960/226408659-cd7395ce-039a-463d-8786-f22e87b092b9.png">


Fix issue #116