### PR TITLE
Ajout d'un composant modale 

### DIFF
--- a/components/modal.js
+++ b/components/modal.js
@@ -31,7 +31,7 @@ const Modal = ({children, title, onClose}) => (
 
     <style jsx>{`
       .modal-wrapper {
-        z-index: 1;
+        z-index: 2;
         position: fixed;
         top: 0;
         bottom: 0;

--- a/components/modal.js
+++ b/components/modal.js
@@ -31,6 +31,7 @@ const Modal = ({children, title, onClose}) => (
 
     <style jsx>{`
       .modal-wrapper {
+        z-index: 1;
         position: fixed;
         top: 0;
         bottom: 0;

--- a/components/modal.js
+++ b/components/modal.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 
 const Modal = ({children, title, onClose}) => (
-  <dialogue className='modal-wrapper fr-grid-row fr-grid-row--center fr-grid-row--middle' onClick={onClose}>
+  <div className='modal-wrapper fr-grid-row fr-grid-row--center fr-grid-row--middle' onClick={onClose}>
     <div className='fr-container fr-container--fluid fr-container-md' onClick={e => e.stopPropagation()}>
       <div className='fr-grid-row fr-grid-row--center'>
         <div className='fr-col-12 fr-col-md-8 fr-col-lg-6'>
@@ -40,7 +40,7 @@ const Modal = ({children, title, onClose}) => (
         background: rgba(0, 0, 0, 0.4);
       }
     `}</style>
-  </dialogue>
+  </div>
 )
 
 Modal.propTypes = {

--- a/components/modal.js
+++ b/components/modal.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types'
+
+const Modal = ({children, title, onClose}) => (
+  <dialogue className='modal-wrapper fr-grid-row fr-grid-row--center fr-grid-row--middle' onClick={onClose}>
+    <div className='fr-container fr-container--fluid fr-container-md' onClick={e => e.stopPropagation()}>
+      <div className='fr-grid-row fr-grid-row--center'>
+        <div className='fr-col-12 fr-col-md-8 fr-col-lg-6'>
+          <div className='fr-modal__body'>
+            <div className='fr-modal__header fr-container fr-grid-row--right'>
+              <button
+                type='button'
+                className='fr-link--close fr-link fr-grid-row fr-grid-row--middle fr-p-1w'
+                aria-label='Fermer la fenêtre modale'
+                onClick={onClose}
+              >
+                Fermer
+              </button>
+            </div>
+            <div className='fr-modal__content'>
+              {title && (
+                <h1 className='fr-modal__title'>
+                  <span className='fr-fi-arrow-right-line fr-fi--lg' />{title}
+                </h1>
+              )}
+              <div>{children}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <style jsx>{`
+      .modal-wrapper {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: rgba(0, 0, 0, 0.4);
+      }
+    `}</style>
+  </dialogue>
+)
+
+Modal.propTypes = {
+  children: PropTypes.node,
+  title: PropTypes.string,
+  onClose: PropTypes.func.isRequired
+}
+
+Modal.defaultProps = {
+  children: null,
+  title: null
+}
+
+export default Modal


### PR DESCRIPTION
Ce composant est réutilisable et permet l'apparition d'une boite de dialogue

Props : 
- `title` : titre de la modale 
- `children` : contenu de la modale
- `onClose` : <required> fonction de fermeture de la modale

La modale se ferme en utilisant le bouton fermer ou en cliquant en dehors de la modale

<img width="1224" alt="Capture d’écran 2023-03-24 à 10 46 50" src="https://user-images.githubusercontent.com/66621960/227487044-6be0e1c6-7efe-4302-b7d3-a5bbb0ebe4a3.png">
