### PR TITLE
Affichages des nouvelles données v3

### DIFF
--- a/components/map-sidebar/pcrs-infos.js
+++ b/components/map-sidebar/pcrs-infos.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types'
 
 import colors from '@/styles/colors.js'
 
+import {formatDate} from '@/lib/date-utils.js'
+
 import {PCRS_DATA_COLORS} from '@/styles/pcrs-data-colors.js'
 
 import Tooltip from '@/components/tooltip.js'
@@ -38,6 +40,19 @@ const LICENCE_LABELS = {
   ferme: 'Fermé'
 }
 
+const PUBLICATIONS = [
+  {label: 'Accès via FTP', value: 'ftp'},
+  {label: 'Accès via un service cloud (oneDrive...)', value: 'cloud'},
+  {label: 'Accès via service HTTP(S)', value: 'http'},
+  {label: 'Aucun moyen d’accès en ligne', value: 'inexistante'}
+]
+
+const DIFFUSIONS = [
+  {label: 'wms', value: 'Diffusion via un service WMS'},
+  {label: 'wmts', value: 'Diffusion via un service WMTS'},
+  {label: 'tms', value: 'Diffusion via un service TMS'}
+]
+
 const PcrsInfos = ({nature, regime, livrables, licence, acteurs}) => {
   const [isActorsShow, setIsActorsShow] = useState(false)
 
@@ -52,8 +67,11 @@ const PcrsInfos = ({nature, regime, livrables, licence, acteurs}) => {
 
   const livrableTooltip = livrable => (
     <div className='tooltip-container'>
-      <div>Nature : <span>{NATURE_LABELS[livrable.nature] || 'N/A'}</span></div>
-      <div>Licence : <span>{LICENCE_LABELS[livrable.licence] || 'N/A'}</span></div>
+      <div>Nature : <br /><span>{NATURE_LABELS[livrable.nature]}</span></div>
+      <div>Licence : <br /><span>{LICENCE_LABELS[livrable.licence]}</span></div>
+      <div>Diffusion : <br /><span>{DIFFUSIONS[livrable.diffusion]}</span></div>
+      {livrable.publication && <div>Type de publication : <br /><span>{PUBLICATIONS[livrable.publication]}</span></div>}
+      {livrable.date_livraison && <div>Livraison : <br /><span>le {formatDate(livrable.date_livraison)}</span></div>}
 
       <style jsx>{`
         .tooltip-container {

--- a/components/map-sidebar/pcrs-infos.js
+++ b/components/map-sidebar/pcrs-infos.js
@@ -25,7 +25,8 @@ const ACTORS_LABELS = {
   presta_vol: 'Prestataires de vol',
   presta_lidar: 'Prestataires Lidar',
   controleur: 'Controleurs',
-  aplc: 'Autorité Publique Locale Compétente'
+  aplc: 'Autorité Publique Locale Compétente',
+  porteur: 'Porteur de projet non-APLC'
 }
 
 const NATURE_LABELS = {

--- a/components/map-sidebar/pcrs-infos.js
+++ b/components/map-sidebar/pcrs-infos.js
@@ -41,23 +41,23 @@ const LICENCE_LABELS = {
   ferme: 'Fermé'
 }
 
-const PUBLICATIONS = [
-  {label: 'Accès via FTP', value: 'ftp'},
-  {label: 'Accès via un service cloud (oneDrive...)', value: 'cloud'},
-  {label: 'Accès via service HTTP(S)', value: 'http'},
-  {label: 'Aucun moyen d’accès en ligne', value: 'inexistante'}
-]
+const PUBLICATIONS = {
+  ftp: 'Accès via FTP',
+  cloud: 'Accès via un service cloud (oneDrive...)',
+  http: 'Accès via service HTTP(S)',
+  inexistante: 'Aucun moyen d’accès en ligne'
+}
 
-const DIFFUSIONS = [
-  {label: 'wms', value: 'Diffusion via un service WMS'},
-  {label: 'wmts', value: 'Diffusion via un service WMTS'},
-  {label: 'tms', value: 'Diffusion via un service TMS'}
-]
+const DIFFUSIONS = {
+  wms: 'Diffusion via un service WMS',
+  wmts: 'Diffusion via un service WMTS',
+  tms: 'Diffusion via un service TMS'
+}
 
 const PcrsInfos = ({nature, regime, livrables, licence, acteurs}) => {
   const [isActorsShow, setIsActorsShow] = useState(false)
 
-  const nomAPLC = acteurs.find(acteur => acteur.role === 'aplc').nom
+  const nomAPLC = acteurs.find(acteur => acteur.role === 'aplc')?.nom
   const {natures: naturesColors, regimes: regimesColors, licences: licencesColors, actors: actorsColors, livrablesNatures} = PCRS_DATA_COLORS
 
   function uniq(items) {
@@ -71,8 +71,8 @@ const PcrsInfos = ({nature, regime, livrables, licence, acteurs}) => {
       <div>Nature : <br /><span>{NATURE_LABELS[livrable.nature]}</span></div>
       <div>Licence : <br /><span>{LICENCE_LABELS[livrable.licence]}</span></div>
       <div>Diffusion : <br /><span>{DIFFUSIONS[livrable.diffusion]}</span></div>
-      {livrable.publication && <div>Type de publication : <br /><span>{PUBLICATIONS[livrable.publication]}</span></div>}
-      {livrable.date_livraison && <div>Livraison : <br /><span>le {formatDate(livrable.date_livraison)}</span></div>}
+      <div>Type de publication : <br /><span>{livrable.publication ? PUBLICATIONS[livrable.publication] : 'N/A'}</span></div>
+      <div>Livraison : <br /><span>{livrable.date_livraison ? `le ${formatDate(livrable.date_livraison)}` : 'N/A'}</span></div>
 
       <style jsx>{`
         .tooltip-container {
@@ -223,4 +223,3 @@ PcrsInfos.propTypes = {
 }
 
 export default PcrsInfos
-


### PR DESCRIPTION
⚠️ PR à merger une fois que la migration vers la V3 est effectuée.

Le passage à la V3 ajoute de nouvelles informations (requises ou non) concernant les livrables.
Cette PR permet d'afficher ces informations dans la tooltip du livrable lorsqu'elles sont disponibles.

Les 3 données qui sont affichées sont : 

- Le type de diffusion
- Le type de publication
- La date de livraison

<img width="401" alt="Capture d’écran 2023-03-29 à 10 26 02" src="https://user-images.githubusercontent.com/66621960/228477855-feea01c0-e9b2-4745-a68e-478101b77dd3.png">