### PR TITLE
Migration vers le modèle v0.3

### DIFF
--- a/lib/__tests__/projets-validator.js
+++ b/lib/__tests__/projets-validator.js
@@ -13,11 +13,13 @@ const validProjet = {
     {
       nom: 'Images raster',
       nature: 'geotiff',
-      diffusion: 'flux',
+      diffusion: 'wms',
       licence: 'ouvert_lo',
       avancement: 18,
       crs: 'ok',
-      compression: null
+      compression: null,
+      date_livraison: '2020-11-28',
+      publication: 'cloud'
     }
   ],
   acteurs: [
@@ -47,7 +49,8 @@ const invalidProjet = {
       nature: 'geotouff',
       diffusion: 'flox',
       licence: 'ouverte_lo',
-      avancement: '12'
+      avancement: '12',
+      publication: 'bonjour'
     }
   ],
   acteurs: [
@@ -117,21 +120,22 @@ test('Create invalid projet', t => {
     validateCreation(invalidProjet)
   }, {instanceOf: Error})
 
-  t.is(error.details.length, 14)
+  t.is(error.details.length, 15)
   t.is(error.details[0].message, '"nom" is required')
   t.is(error.details[1].message, '"regime" must be one of [production, maj]')
   t.is(error.details[2].message, '"nature" must be one of [vecteur, raster, mixte]')
   t.is(error.details[3].message, '"livrables[0].nature" must be one of [geotiff, jpeg2000, gml]')
   t.is(error.details[4].message, '"livrables[0].licence" must be one of [ouvert_lo, ouvert_odbl, ferme]')
-  t.is(error.details[5].message, '"livrables[0].diffusion" must be one of [telechargement, flux]')
+  t.is(error.details[5].message, '"livrables[0].diffusion" must be one of [wms, wmts, tms, null]')
   t.is(error.details[6].message, '"livrables[0].avancement" must be a number')
-  t.is(error.details[7].message, '"acteurs[0].telephone" with value "+33324594528333" fails to match the required pattern: /^((\\+)33|0|0033)[1-9](\\d{2}){4}$/')
-  t.is(error.details[8].message, '"acteurs[0].role" must be one of [aplc, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
-  t.is(error.details[9].message, '"acteurs[1].role" must be one of [aplc, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
-  t.is(error.details[10].message, '"perimetres[0]" failed custom validation because Territory not found: departement:00')
-  t.is(error.details[11].message, 'Date invalide')
-  t.is(error.details[12].message, '"subventions[0].nature" is required')
-  t.is(error.details[13].message, '"subventions[0].ntr" is not allowed')
+  t.is(error.details[7].message, '"livrables[0].publication" must be one of [ftp, cloud, http, inexistante, null]')
+  t.is(error.details[8].message, '"acteurs[0].telephone" with value "+33324594528333" fails to match the required pattern: /^((\\+)33|0|0033)[1-9](\\d{2}){4}$/')
+  t.is(error.details[9].message, '"acteurs[0].role" must be one of [aplc, porteur, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
+  t.is(error.details[10].message, '"acteurs[1].role" must be one of [aplc, porteur, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
+  t.is(error.details[11].message, '"perimetres[0]" failed custom validation because Territory not found: departement:00')
+  t.is(error.details[12].message, 'Date invalide')
+  t.is(error.details[13].message, '"subventions[0].nature" is required')
+  t.is(error.details[14].message, '"subventions[0].ntr" is not allowed')
 })
 
 // Test validateChanges
@@ -145,18 +149,19 @@ test('Update invalid projet', t => {
     validateChanges(invalidProjet)
   }, {instanceOf: Error})
 
-  t.is(error.details.length, 11)
+  t.is(error.details.length, 12)
   t.is(error.details[0].message, '"regime" must be one of [production, maj]')
   t.is(error.details[1].message, '"nature" must be one of [vecteur, raster, mixte]')
   t.is(error.details[2].message, '"livrables[0].nature" must be one of [geotiff, jpeg2000, gml]')
   t.is(error.details[3].message, '"livrables[0].licence" must be one of [ouvert_lo, ouvert_odbl, ferme]')
-  t.is(error.details[4].message, '"livrables[0].diffusion" must be one of [telechargement, flux, null]')
+  t.is(error.details[4].message, '"livrables[0].diffusion" must be one of [wms, wmts, tms, null]')
   t.is(error.details[5].message, '"livrables[0].avancement" must be a number')
-  t.is(error.details[6].message, '"acteurs[0].telephone" with value "+33324594528333" fails to match the required pattern: /^((\\+)33|0|0033)[1-9](\\d{2}){4}$/')
-  t.is(error.details[7].message, '"acteurs[0].role" must be one of [aplc, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
-  t.is(error.details[8].message, '"acteurs[1].role" must be one of [aplc, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
-  t.is(error.details[9].message, 'Date invalide')
-  t.is(error.details[10].message, '"subventions[0].ntr" is not allowed')
+  t.is(error.details[6].message, '"livrables[0].publication" must be one of [ftp, cloud, http, inexistante, null]')
+  t.is(error.details[7].message, '"acteurs[0].telephone" with value "+33324594528333" fails to match the required pattern: /^((\\+)33|0|0033)[1-9](\\d{2}){4}$/')
+  t.is(error.details[8].message, '"acteurs[0].role" must be one of [aplc, porteur, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
+  t.is(error.details[9].message, '"acteurs[1].role" must be one of [aplc, porteur, financeur, diffuseur, presta_vol, presta_lidar, controleur]')
+  t.is(error.details[10].message, 'Date invalide')
+  t.is(error.details[11].message, '"subventions[0].ntr" is not allowed')
 })
 
 // Test validateJoiDate

--- a/lib/projets-validator.js
+++ b/lib/projets-validator.js
@@ -39,6 +39,7 @@ const acteursSchemaCreation = Joi.object().keys({
   telephone: Joi.string().pattern(/^((\+)33|0|0033)[1-9](\d{2}){4}$/).allow(null),
   role: Joi.valid(
     'aplc',
+    'porteur',
     'financeur',
     'diffuseur',
     'presta_vol',
@@ -73,12 +74,20 @@ const livrablesSchemaCreation = Joi.object().keys({
     'ferme'
   ).required(),
   diffusion: Joi.valid(
-    'telechargement',
-    'flux'
-  ),
+    'wms',
+    'wmts',
+    'tms'
+  ).allow(null),
+  date_livraison: Joi.custom(validateJoiDate).allow(null),
   crs: Joi.string().allow(null),
   avancement: Joi.number().allow(null),
-  compression: Joi.string().allow(null)
+  compression: Joi.string().allow(null),
+  publication: Joi.valid(
+    'ftp',
+    'cloud',
+    'http',
+    'inexistante'
+  ).allow(null)
 })
 
 const subventionsSchemaCreation = Joi.object().keys({
@@ -120,6 +129,7 @@ const acteursSchemaUpdate = Joi.object().keys({
   telephone: Joi.string().pattern(/^((\+)33|0|0033)[1-9](\d{2}){4}$/).allow(null),
   role: Joi.valid(
     'aplc',
+    'porteur',
     'financeur',
     'diffuseur',
     'presta_vol',
@@ -154,12 +164,20 @@ const livrablesSchemaUpdate = Joi.object().keys({
     'ferme'
   ),
   diffusion: Joi.valid(
-    'telechargement',
-    'flux'
+    'wms',
+    'wmts',
+    'tms'
   ).allow(null),
+  date_livraison: Joi.custom(validateJoiDate).allow(null),
   crs: Joi.string().allow(null),
   avancement: Joi.number().allow(null),
-  compression: Joi.string().allow(null)
+  compression: Joi.string().allow(null),
+  publication: Joi.valid(
+    'ftp',
+    'cloud',
+    'http',
+    'inexistante'
+  ).allow(null)
 })
 
 const subventionsSchemaUpdate = Joi.object().keys({

--- a/scripts/migration-v03.js
+++ b/scripts/migration-v03.js
@@ -21,11 +21,30 @@ for (const projet of projetsWithDiffusionTelechargement) {
   )
 }
 
-for (const projet of projetsWithDiffusionFlux) {
-  console.log('Modification du projet : ' + projet.nom)
-  await mongo.db.collection('projets').findOneAndUpdate(
-    {livrables: {$elemMatch: {diffusion: 'flux'}}},
-    {$set: {'livrables.$.diffusion': 'wms', 'livrables.$.publication': 'ftp'}}
+const projets = await mongo.db.collection('projets').find().toArray()
+
+for (const projet of projets) {
+  const updatedLivrables = projet.livrables.map(livrable => {
+    if (livrable.diffusion === 'flux') {
+      return {
+        diffusion: 'wms',
+        publication: 'ftp'
+      }
+    }
+
+    if (livrable.diffusion === 'telechargement') {
+      return {
+        diffusion: null,
+        publication: 'ftp'
+      }
+    }
+
+    return livrable
+  })
+
+  await mongo.db.collection('projets').updateOne(
+    {_id: projet._id},
+    {$set: {livrables: updatedLivrables}}
   )
 }
 

--- a/scripts/migration-v03.js
+++ b/scripts/migration-v03.js
@@ -16,6 +16,7 @@ for (const projet of projets) {
   const updatedLivrables = projet.livrables.map(livrable => {
     if (livrable.diffusion === 'flux') {
       return {
+        ...livrable,
         diffusion: 'wms',
         publication: 'ftp'
       }
@@ -23,6 +24,7 @@ for (const projet of projets) {
 
     if (livrable.diffusion === 'telechargement') {
       return {
+        ...livrable,
         diffusion: null,
         publication: 'ftp'
       }

--- a/scripts/migration-v03.js
+++ b/scripts/migration-v03.js
@@ -1,25 +1,14 @@
 #!/usr/bin/env node
+/* eslint-disable import/first */
 /* eslint-disable no-await-in-loop */
+
+import * as dotenv from 'dotenv'
+
+dotenv.config()
 
 import mongo from '../server/util/mongo.js'
 
 await mongo.connect()
-
-const projetsWithDiffusionFlux = await mongo.db.collection('projets').find(
-  {livrables: {$elemMatch: {diffusion: 'flux'}}}
-).toArray()
-
-const projetsWithDiffusionTelechargement = await mongo.db.collection('projets').find(
-  {livrables: {$elemMatch: {diffusion: 'telechargement'}}}
-).toArray()
-
-for (const projet of projetsWithDiffusionTelechargement) {
-  console.log('Modification du projet : ' + projet.nom)
-  await mongo.db.collection('projets').findOneAndUpdate(
-    {livrables: {$elemMatch: {diffusion: 'telechargement'}}},
-    {$set: {'livrables.$.diffusion': null, 'livrables.$.publication': 'ftp'}}
-  )
-}
 
 const projets = await mongo.db.collection('projets').find().toArray()
 

--- a/scripts/migration-v03.js
+++ b/scripts/migration-v03.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/* eslint-disable no-await-in-loop */
+
+import mongo from '../server/util/mongo.js'
+
+await mongo.connect()
+
+const projetsWithDiffusionFlux = await mongo.db.collection('projets').find(
+  {livrables: {$elemMatch: {diffusion: 'flux'}}}
+).toArray()
+
+const projetsWithDiffusionTelechargement = await mongo.db.collection('projets').find(
+  {livrables: {$elemMatch: {diffusion: 'telechargement'}}}
+).toArray()
+
+for (const projet of projetsWithDiffusionTelechargement) {
+  console.log('Modification du projet : ' + projet.nom)
+  await mongo.db.collection('projets').findOneAndUpdate(
+    {livrables: {$elemMatch: {diffusion: 'telechargement'}}},
+    {$set: {'livrables.$.diffusion': null, 'livrables.$.publication': 'ftp'}}
+  )
+}
+
+for (const projet of projetsWithDiffusionFlux) {
+  console.log('Modification du projet : ' + projet.nom)
+  await mongo.db.collection('projets').findOneAndUpdate(
+    {livrables: {$elemMatch: {diffusion: 'flux'}}},
+    {$set: {'livrables.$.diffusion': 'wms', 'livrables.$.publication': 'ftp'}}
+  )
+}
+
+await mongo.disconnect()
+

--- a/server/__tests__/projets.js
+++ b/server/__tests__/projets.js
@@ -31,7 +31,7 @@ const validProjet = {
     {
       nom: 'Nom du livrable',
       nature: 'geotiff',
-      diffusion: 'telechargement',
+      diffusion: 'wmts',
       licence: 'ouvert_odbl',
       avancement: 100,
       crs: 'EPSG:2971',


### PR DESCRIPTION

_**Cette PR ajoute un script de migration des données des projets PCRS vers le modèle en version 0.3**_

### Modification du modèle :
→ Si `diffusion: flux` on retourne : `{diffusion: 'wms', publication: 'ftp'}`   
→ Si `diffusion: 'telechargement'` on retourne : `{diffusion: null, publication: 'ftp'}`

- Nouveau champ dans `acteur.role` → `porteur`
- Nouveau champ dans `subventions` → `detr`
- Nouveau champ `livrables.publication` → valeurs : `'ftp', 'cloud', 'http', 'inexistante'`
- Nouvelles valeurs pour le champ `livrables.diffusion` → `'wms', 'wmts', 'tms'`
- Nouveau champ dans `livrables` → `date_livraison`

### Changements : 
- Ajout d’un script qui modifie les valeurs dans la base de données
- Mise à jour de la validation des projets
- Mise à jour des tests