### PR TITLE
Corrige le problème de validation du code siren

### DIFF
--- a/components/suivi-form/acteurs/index.js
+++ b/components/suivi-form/acteurs/index.js
@@ -249,12 +249,12 @@ const Acteurs = ({acteurs, handleActors, hasMissingData, onRequiredFormOpen}) =>
   }, [updatingActorIndex])
 
   useEffect(() => {
-    if (nom && role && !hasInvalidInput && (!phone || isPhoneNumberValid)) {
+    if (nom && role && siren && !hasInvalidInput && (!phone || isPhoneNumberValid)) {
       setIsFormComplete(true)
     } else {
       setIsFormComplete(false)
     }
-  }, [nom, role, hasInvalidInput, phone, isPhoneNumberValid])
+  }, [nom, role, siren, hasInvalidInput, phone, isPhoneNumberValid])
 
   useEffect(() => {
     if (phone) {

--- a/components/suivi-form/acteurs/index.js
+++ b/components/suivi-form/acteurs/index.js
@@ -319,6 +319,8 @@ const Acteurs = ({acteurs, handleActors, hasMissingData, onRequiredFormOpen}) =>
                     nom: foundActorName,
                     siren: item
                   })
+
+                  setIsSirenValid(/^\d{9}$/.test(item))
                 }}
               />
             </div>
@@ -330,12 +332,12 @@ const Acteurs = ({acteurs, handleActors, hasMissingData, onRequiredFormOpen}) =>
                 ariaLabel='numéro siren de l’entreprise'
                 description='SIREN de l’entreprise'
                 errorMessage={handleErrors(siren, 'siren')}
+                onBlur={e => setIsSirenValid(/^\d{9}$/.test(e.target.value))}
                 onValueChange={e => {
                   setActeur({
                     ...acteur,
                     siren: e.target.value
                   })
-                  setIsSirenValid(/^\d{9}$/.test(e.target.value))
                 }}
               />
             </div>

--- a/components/text-input.js
+++ b/components/text-input.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 
-const TextInput = ({label, value, type, ariaLabel, placeholder, errorMessage, description, isRequired, isDisabled, onValueChange}) => {
+const TextInput = ({label, value, type, ariaLabel, placeholder, errorMessage, description, isRequired, isDisabled, onValueChange, onFocus, onBlur}) => {
   const inputState = errorMessage ? 'error' : ''
 
   return (
@@ -19,6 +19,8 @@ const TextInput = ({label, value, type, ariaLabel, placeholder, errorMessage, de
         placeholder={placeholder}
         disabled={isDisabled}
         onChange={onValueChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
       />
 
       {errorMessage && <p id='text-input-error-desc-error' className='fr-error-text'>{errorMessage}</p>}

--- a/components/text-input.js
+++ b/components/text-input.js
@@ -48,7 +48,9 @@ TextInput.propTypes = {
   description: PropTypes.string,
   isRequired: PropTypes.bool,
   isDisabled: PropTypes.bool,
-  onValueChange: PropTypes.func
+  onValueChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func
 }
 
 TextInput.defaultProps = {
@@ -60,7 +62,9 @@ TextInput.defaultProps = {
   errorMessage: null,
   description: null,
   isRequired: false,
-  isDisabled: false
+  isDisabled: false,
+  onFocus: null,
+  onBlur: null
 }
 
 export default TextInput


### PR DESCRIPTION

La validation du numéro siren se faisant uniquement lorsque l’utilisateur entrait un code siren, le remplissage automatique ne modifiait pas la variable (`isSirenValid`).

_**Ceci est un "quickfix", il serait préférable de revoir la gestion des erreurs.**_

- Ajout des événements `onFocus` et `onBlur` sur le composant `inputText`
- Ajout du code siren dans la validation `isFormComplete`
- Modification du moment de vérification du code siren

Fix #140 