### PR TITLE
Ajout d’un lien vers le formulaire sur la carte de suivi

### DIFF
--- a/components/map/map.js
+++ b/components/map/map.js
@@ -1,12 +1,13 @@
 import {createRoot} from 'react-dom/client' // eslint-disable-line n/file-extension-in-import
 import {useEffect, useRef} from 'react'
 import PropTypes from 'prop-types'
+import Link from 'next/link'
+
 import maplibreGl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
-import Link from 'next/link'
+
 import departementFillLayer from './layers/departement-fill.json'
 import departementLayer from './layers/departement-layer.json'
-
 import vector from './styles/vector.json'
 
 import Popup from '@/components/map/popup.js'

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -136,14 +136,15 @@ const Map = ({handleClick, isMobile, geometry}) => {
         <Link href='/formulaire-suivi'>
           <button
             type='button'
-            label='+'
-            className='fr-btn fr-icon-add-circle-fill'
+            className='fr-btn fr-btn--icon-left fr-icon-add-circle-fill'
             style={{
               position: 'fixed',
               right: 10,
               bottom: `${isMobile ? '110px' : '45px'}`
             }}
-          />
+          >
+            Ajouter un projet
+          </button>
         </Link>
       )}
     </div>

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -3,6 +3,7 @@ import {useEffect, useRef} from 'react'
 import PropTypes from 'prop-types'
 import maplibreGl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
+import Link from 'next/link'
 import departementFillLayer from './layers/departement-fill.json'
 import departementLayer from './layers/departement-layer.json'
 
@@ -131,6 +132,20 @@ const Map = ({handleClick, isMobile, geometry}) => {
     <div style={{position: 'relative', height: '100%', width: '100%'}}>
       <div ref={mapNode} style={{width: '100%', height: '100%'}} />
       <Legend isMobile={isMobile === true} />
+      {localStorage.getItem('Token') && (
+        <Link href='/formulaire-suivi'>
+          <button
+            type='button'
+            label='+'
+            className='fr-btn fr-icon-add-circle-fill'
+            style={{
+              position: 'fixed',
+              right: 10,
+              bottom: `${isMobile ? '110px' : '45px'}`
+            }}
+          />
+        </Link>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Cette PR ajoute un bouton, sur la carte de suivi des PCRS, permettant d’accéder au formulaire.

Le bouton est affiché uniquement lorsque l’utilisateur a entré son jeton.

Fix #142 

## Captures : 

![image](https://user-images.githubusercontent.com/56537238/230352290-d8c7f849-f393-4c03-b754-622811ccf70e.png)


![capture_mobile](https://user-images.githubusercontent.com/56537238/230352702-0166ed31-71be-4a2b-a0cd-c5992d4ef16b.png)
