### PR TITLE
Gestion de la fermeture de la modal d'authentification

### DIFF
--- a/components/suivi-form/edit-form.js
+++ b/components/suivi-form/edit-form.js
@@ -43,7 +43,10 @@ const EditForm = ({project}) => {
     setIsLoading(false)
   }, [])
 
-  const handleModal = () => setIsAuthentificationModalOpen(!isAuthentificationModalOpen)
+  const handleModalClose = () => {
+    setIsAuthentificationModalOpen(!isAuthentificationModalOpen)
+    router.push('/suivi-pcrs')
+  }
 
   const handleSubmit = async event => {
     event.preventDefault()
@@ -120,7 +123,7 @@ const EditForm = ({project}) => {
         <h2 className='fr-mt-5w fr-mb-0'>Formulaire de suivi PCRS</h2>
       </div>
       <div className='fr-p-5w'>
-        {!isLoading && !token && <AuthentificationModal handleToken={setToken} handleModal={handleModal} />}
+        {!isLoading && !token && <AuthentificationModal handleToken={setToken} handleModal={handleModalClose} />}
 
         <p className='required-disclaimer'>Les champs indiqués par une * sont obligatoires</p>
 

--- a/pages/formulaire-suivi/index.js
+++ b/pages/formulaire-suivi/index.js
@@ -41,7 +41,10 @@ const FormulaireSuivi = () => {
     setIsLoading(false)
   }, [])
 
-  const handleModal = () => setIsAuthentificationModalOpen(!isAuthentificationModalOpen)
+  const handleModalClose = () => {
+    setIsAuthentificationModalOpen(!isAuthentificationModalOpen)
+    router.push('/suivi-pcrs')
+  }
 
   const handleSubmit = async event => {
     event.preventDefault()
@@ -125,7 +128,7 @@ const FormulaireSuivi = () => {
         <h2 className='fr-mt-5w fr-mb-0'>Formulaire de suivi PCRS</h2>
       </div>
       <div className='fr-my-5w fr-p-5w'>
-        {!isLoading && !token && <AuthentificationModal handleToken={setToken} handleModal={handleModal} />}
+        {!isLoading && !token && <AuthentificationModal handleToken={setToken} handleModal={handleModalClose} />}
 
         <p className='required-disclaimer'>Les champs indiqués par une * sont obligatoires</p>
 


### PR DESCRIPTION
Lorsque l'utilisateur se trouve sur la page d'édition ou de création de suivi de projet **sans avoir enregistré de token**, le bouton de fermeture de la modale d'authentification ne génère aucun effet.

Cette PR redirige l'utilisateur vers la page de la carte des suivis si celui-ci referme la modale avant d'avoir enregistré un token valide.

https://user-images.githubusercontent.com/66621960/231211296-86914fb6-0a70-4184-b5cc-407b562babdf.mov


Close #145