### PR TITLE
Affichage les identifiants des territoires

### DIFF
--- a/components/suivi-form/perimetres/index.js
+++ b/components/suivi-form/perimetres/index.js
@@ -22,7 +22,7 @@ const renderItem = (item, isHighlighted) => {
 
   return (
     <div key={code} className='item fr-px-1w fr-py-2w'>
-      {nom}
+      {nom} - {code}
 
       <style jsx>{`
         .item {


### PR DESCRIPTION
Dans l'auto-complete du formulaire, section territoires, les identifiants des résultats proposés sont affichés afin de discriminer les éventuels doublons.

<img width="1372" alt="Capture d’écran 2023-04-12 à 15 12 41" src="https://user-images.githubusercontent.com/66621960/231468664-5e322843-7d4e-4add-b615-22f185112891.png">

<img width="744" alt="Capture d’écran 2023-04-12 à 15 10 13" src="https://user-images.githubusercontent.com/66621960/231468743-54c868db-245a-483b-add4-859f10c772f0.png">

Close #154