### PR TITLE
Suivi-projet : Gestion des projets superposés

### DIFF
--- a/components/map-sidebar/index.js
+++ b/components/map-sidebar/index.js
@@ -11,7 +11,7 @@ import PcrsInfos from '@/components/map-sidebar/pcrs-infos.js'
 import Documents from '@/components/map-sidebar/documents.js'
 import Contact from '@/components/map-sidebar/contact.js'
 
-const MapSidebar = ({projet, onClose}) => {
+const MapSidebar = ({projet, onClose, onProjetChange, projets}) => {
   const {status} = PCRS_DATA_COLORS
   const {nom, territoires, _id, etapes, source, documentation, contrat, acteurs} = projet
 
@@ -22,7 +22,14 @@ const MapSidebar = ({projet, onClose}) => {
 
   return (
     <>
-      <Header projectId={_id} projectName={nom} territoires={territoires} onSidebarClose={onClose} />
+      <Header
+        projets={projets}
+        projectId={_id}
+        projectName={nom}
+        territoires={territoires}
+        onSidebarClose={onClose}
+        onProjetChange={onProjetChange}
+      />
       <div className='infos-container'>
         <h2 className='fr-text--lead fr-mb-1w'>État d’avancement</h2>
         <div className='actual-status fr-mb-3w'>
@@ -81,9 +88,16 @@ const MapSidebar = ({projet, onClose}) => {
   )
 }
 
+MapSidebar.defaultProps = {
+  projets: null,
+  onProjetChange: null
+}
+
 MapSidebar.propTypes = {
   projet: PropTypes.object.isRequired,
-  onClose: PropTypes.func.isRequired
+  onClose: PropTypes.func.isRequired,
+  projets: PropTypes.array,
+  onProjetChange: PropTypes.func
 }
 
 export default MapSidebar

--- a/components/map-sidebar/project-header.js
+++ b/components/map-sidebar/project-header.js
@@ -11,7 +11,7 @@ import Button from '@/components/button.js'
 import Modal from '@/components/modal.js'
 import AuthentificationModal from '@/components/suivi-form/authentification-modal.js'
 
-const Header = ({projectId, projectName, territoires}) => {
+const Header = ({projectId, projectName, territoires, projets, onProjetChange}) => {
   const router = useRouter()
   const [isTerritoiresShow, setIsTerritoiresShow] = useState(false)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
@@ -146,7 +146,16 @@ const Header = ({projectId, projectName, territoires}) => {
           </span>
         ))
       )}
-
+      {projets && projets.length > 1 && (
+        <div className='fr-select-group fr-p-3v fr-mt-3w' style={{borderTop: '1px solid white'}}>
+          <label className='fr-label' style={{color: 'white'}}>Sélectionnez un autre projet</label>
+          <select className='fr-select' onChange={onProjetChange}>
+            {projets.map((projet, idx) => (
+              <option key={projet.nom} value={idx}>{projet.nom}</option>
+            ))}
+          </select>
+        </div>
+      )}
       <style jsx>{`
         .header {
           padding: 1em;
@@ -185,14 +194,18 @@ const Header = ({projectId, projectName, territoires}) => {
   )
 }
 
+Header.defaultProps = {
+  territoires: [],
+  projets: null,
+  onProjetChange: null
+}
+
 Header.propTypes = {
   projectId: PropTypes.string.isRequired,
   projectName: PropTypes.string.isRequired,
-  territoires: PropTypes.array
-}
-
-Header.defaultProps = {
-  territoires: []
+  territoires: PropTypes.array,
+  projets: PropTypes.array,
+  onProjetChange: PropTypes.func
 }
 
 export default Header

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -63,7 +63,9 @@ const Map = ({handleClick, isMobile, geometry}) => {
 
           popupRoot.render(
             <Popup
+              key={projet.nom}
               projet={projet}
+              otherProjets={e.features.length}
             />
           )
 

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -65,7 +65,7 @@ const Map = ({handleClick, isMobile, geometry}) => {
             <Popup
               key={projet.nom}
               projet={projet}
-              otherProjets={e.features.length}
+              numberOfProjets={e.features.length}
             />
           )
 

--- a/components/map/popup.js
+++ b/components/map/popup.js
@@ -6,7 +6,7 @@ import {PCRS_DATA_COLORS} from '@/styles/pcrs-data-colors.js'
 
 import {formatDate} from '@/lib/date-utils.js'
 
-const Popup = ({projet, otherProjets}) => {
+const Popup = ({projet, numberOfProjets}) => {
   const {aplc, dateStatut, nom, nature, statut} = projet
   const {status, natures} = PCRS_DATA_COLORS
 
@@ -18,9 +18,9 @@ const Popup = ({projet, otherProjets}) => {
       }}
     >
       <div className='title'><u>{nom}</u></div>
-      {otherProjets > 1 && (
+      {numberOfProjets > 1 && (
         <div className='more'>
-          <i>...et {otherProjets - 1} {otherProjets === 2 ? 'autre projet' : 'autres projets'}</i>
+          <i>...et {numberOfProjets - 1} {numberOfProjets === 2 ? 'autre projet' : 'autres projets'}</i>
         </div>
       )}
       <div className='fr-text fr-text--sm fr-grid-row--center fr-pt-3v'>
@@ -81,7 +81,7 @@ const Popup = ({projet, otherProjets}) => {
 
 Popup.propTypes = {
   projet: PropTypes.object.isRequired,
-  otherProjets: PropTypes.number
+  numberOfProjets: PropTypes.number
 }
 
 export default Popup

--- a/components/map/popup.js
+++ b/components/map/popup.js
@@ -6,7 +6,7 @@ import {PCRS_DATA_COLORS} from '@/styles/pcrs-data-colors.js'
 
 import {formatDate} from '@/lib/date-utils.js'
 
-const Popup = ({projet}) => {
+const Popup = ({projet, otherProjets}) => {
   const {aplc, dateStatut, nom, nature, statut} = projet
   const {status, natures} = PCRS_DATA_COLORS
 
@@ -52,6 +52,11 @@ const Popup = ({projet}) => {
           <div><i>{aplc}</i></div>
         </div>
       </div>
+      {otherProjets > 1 && (
+        <p className='fr-pt-5v'>
+          <i>Et {otherProjets - 1} {otherProjets === 2 ? 'autre projet' : 'autres projets'}</i>
+        </p>
+      )}
       <style>{`
         .title {
           color: ${colors.blueFranceSun113};
@@ -72,7 +77,8 @@ const Popup = ({projet}) => {
 }
 
 Popup.propTypes = {
-  projet: PropTypes.object.isRequired
+  projet: PropTypes.object.isRequired,
+  otherProjets: PropTypes.number
 }
 
 export default Popup

--- a/components/map/popup.js
+++ b/components/map/popup.js
@@ -17,8 +17,13 @@ const Popup = ({projet, otherProjets}) => {
         textAlign: 'center'
       }}
     >
-      <h6 className='title fr-text fr-text--md'><u>{nom}</u></h6>
-      <div className='fr-text fr-text--sm fr-grid-row fr-pb-3v'>
+      <div className='title'><u>{nom}</u></div>
+      {otherProjets > 1 && (
+        <div className='more'>
+          <i>...et {otherProjets - 1} {otherProjets === 2 ? 'autre projet' : 'autres projets'}</i>
+        </div>
+      )}
+      <div className='fr-text fr-text--sm fr-grid-row--center fr-pt-3v'>
         {statut !== 'livre' && (
           <span>En</span>
         )}
@@ -52,14 +57,12 @@ const Popup = ({projet, otherProjets}) => {
           <div><i>{aplc}</i></div>
         </div>
       </div>
-      {otherProjets > 1 && (
-        <p className='fr-pt-5v'>
-          <i>Et {otherProjets - 1} {otherProjets === 2 ? 'autre projet' : 'autres projets'}</i>
-        </p>
-      )}
       <style>{`
         .title {
           color: ${colors.blueFranceSun113};
+          font-size: 1.4em;
+          font-weight: bold;
+          padding-bottom: 5px;
         }
         .container {
           display: flex;

--- a/layouts/map.js
+++ b/layouts/map.js
@@ -6,7 +6,7 @@ import DeviceContext from '@/contexts/device.js'
 import Map from '@/components/map/index.js'
 import MapSidebar from '@/components/map-sidebar/index.js'
 
-export const Mobile = ({handleClick, handleTitleClick, projet, isOpen, setIsOpen, geometry}) => {
+export const Mobile = ({handleClick, handleTitleClick, projet, isOpen, setIsOpen, geometry, projets, onProjetChange}) => {
   const {viewHeight} = useContext(DeviceContext)
 
   return (
@@ -81,8 +81,13 @@ export const Mobile = ({handleClick, handleTitleClick, projet, isOpen, setIsOpen
             )
           )}
         </div>
-        {isOpen && (
-          <MapSidebar projet={projet} onClose={() => setIsOpen(false)} />
+        {isOpen && projet && (
+          <MapSidebar
+            projet={projet}
+            projets={projets}
+            onProjetChange={onProjetChange}
+            onClose={() => setIsOpen(false)}
+          />
         )}
       </div>
     </div>
@@ -92,7 +97,9 @@ export const Mobile = ({handleClick, handleTitleClick, projet, isOpen, setIsOpen
 Mobile.defaultProps = {
   handleTitleClick: null,
   projet: null,
-  isOpen: false
+  isOpen: false,
+  projets: null,
+  onProjetChange: null
 }
 
 Mobile.propTypes = {
@@ -101,10 +108,12 @@ Mobile.propTypes = {
   handleTitleClick: PropTypes.func,
   projet: PropTypes.object,
   isOpen: PropTypes.bool,
-  geometry: PropTypes.object
+  geometry: PropTypes.object,
+  projets: PropTypes.array,
+  onProjetChange: PropTypes.func
 }
 
-export const Desktop = ({handleClick, projet, isOpen, setIsOpen, geometry}) => (
+export const Desktop = ({handleClick, projet, isOpen, setIsOpen, geometry, onProjetChange, projets}) => (
   <div
     style={{
       display: 'flex',
@@ -124,7 +133,11 @@ export const Desktop = ({handleClick, projet, isOpen, setIsOpen, geometry}) => (
           }}
         >
           {isOpen && (
-            <MapSidebar projet={projet} onClose={() => setIsOpen(false)} />
+            <MapSidebar
+              projet={projet}
+              projets={projets}
+              onProjetChange={onProjetChange}
+              onClose={() => setIsOpen(false)} />
           )}
         </div>
         <button
@@ -160,7 +173,9 @@ export const Desktop = ({handleClick, projet, isOpen, setIsOpen, geometry}) => (
 
 Desktop.defaultProps = {
   projet: null,
-  isOpen: false
+  isOpen: false,
+  projets: null,
+  onProjetChange: null
 }
 
 Desktop.propTypes = {
@@ -168,6 +183,8 @@ Desktop.propTypes = {
   setIsOpen: PropTypes.func,
   projet: PropTypes.object,
   isOpen: PropTypes.bool,
-  geometry: PropTypes.object
+  geometry: PropTypes.object,
+  projets: PropTypes.array,
+  onProjetChange: PropTypes.func
 }
 

--- a/pages/suivi-pcrs.js
+++ b/pages/suivi-pcrs.js
@@ -11,11 +11,15 @@ const PcrsMap = () => {
   const Layout = useMemo(() => isMobileDevice ? Mobile : Desktop, [isMobileDevice])
   const [isOpen, setIsOpen] = useState(false)
   const [projet, setProjet] = useState()
+  const [projets, setProjets] = useState()
   const [geometry, setGeometry] = useState()
 
   const handleClick = useCallback(async e => {
-    const projet = await getProject(e.features[0].properties._id)
-    setProjet(projet)
+    setProjets([])
+    const promises = e.features.map(f => getProject(f.properties._id))
+    const projets = await Promise.all(promises)
+    setProjets(prevProjets => [...prevProjets, ...projets])
+
     setIsOpen(true)
   }, [])
 
@@ -24,6 +28,12 @@ const PcrsMap = () => {
       setIsOpen(!isOpen)
     }
   }
+
+  useEffect(() => {
+    if (projets && projets.length > 0) {
+      setProjet(projets[0])
+    }
+  }, [projets])
 
   useEffect(() => {
     async function getGeometry() {
@@ -47,9 +57,11 @@ const PcrsMap = () => {
         handleClick={handleClick}
         handleTitleClick={handleTitleClick}
         projet={projet}
+        projets={projets}
+        geometry={geometry}
         isOpen={isOpen}
         setIsOpen={setIsOpen}
-        geometry={geometry}
+        onProjetChange={e => setProjet(projets[e.target.value])}
       />
     </Page>
   )

--- a/pages/suivi-pcrs.js
+++ b/pages/suivi-pcrs.js
@@ -15,10 +15,14 @@ const PcrsMap = () => {
   const [geometry, setGeometry] = useState()
 
   const handleClick = useCallback(async e => {
-    setProjets([])
-    const promises = e.features.map(f => getProject(f.properties._id))
-    const projets = await Promise.all(promises)
-    setProjets(prevProjets => [...prevProjets, ...projets])
+    try {
+      setProjets([])
+      const promises = e.features.map(f => getProject(f.properties._id))
+      const projets = await Promise.all(promises)
+      setProjets(prevProjets => [...prevProjets, ...projets])
+    } catch {
+      throw new Error('Projet introuvable')
+    }
 
     setIsOpen(true)
   }, [])


### PR DESCRIPTION
## Détails : 

Il peut arriver qu’un territoire soit couvert par plusieurs projets PCRS.
Actuellement, on ne peut afficher les détails que pour le projet le plus récent.

## Modifications : 

- Ajout d'un message dans la fenêtre contextuelle de la carte qui indique que le projet survolé possède plusieurs projets PCRS.
- Ajout d'un sélecteur dans l'en tête du panneau latéral permettant de sélectionner les projets.

## Captures : 

![Capture d’écran 2023-04-12 à 16 28 49](https://user-images.githubusercontent.com/56537238/231490804-1d4b6ef4-176b-4309-b1f6-261bd18c060a.png)

![Capture d’écran 2023-04-12 à 16 29 53](https://user-images.githubusercontent.com/56537238/231490887-f1f6dd16-ab8f-43c8-9d45-4511c66cdd67.png)

![Capture d’écran 2023-04-12 à 16 32 23](https://user-images.githubusercontent.com/56537238/231491025-17a95414-0365-4843-bb91-34e14743cdb4.png)

![Enregistrement de l’écran 2023-04-12 à 14 42 02](https://user-images.githubusercontent.com/56537238/231492839-0b8cee3f-8ac0-4988-b4a6-650f9524eb53.gif)
