### PR TITLE
Correction de l'affichage des etapes de projets sans date

### DIFF
--- a/components/map-sidebar/index.js
+++ b/components/map-sidebar/index.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
-import {find, maxBy} from 'lodash'
+import {find} from 'lodash'
 
 import {formatDate} from '@/lib/date-utils.js'
+import {findClosestEtape} from '@/lib/suivi-pcrs.js'
 import {PCRS_DATA_COLORS} from '@/styles/pcrs-data-colors.js'
 
 import Header from '@/components/map-sidebar/project-header.js'
@@ -20,10 +21,7 @@ const MapSidebar = ({projet, onClose}) => {
   const projectStartDate = formatDate(find(projet.etapes, {statut: 'investigation'}).date_debut)
   const isObsolete = statut === 'obsolete'
 
-  const now = new Date()
-
-  const filteredLaterSteps = etapes.filter(etape => new Date(etape.date_debut) <= now)
-  const closestPostStep = maxBy(filteredLaterSteps, etape => new Date(etape.date_debut))
+  const closestPostStep = findClosestEtape(etapes)
 
   return (
     <>

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -1,7 +1,21 @@
+import {maxBy} from 'lodash-es'
+
 import HttpError from './http-error.js'
 
 const PUBLIC_URL = process.env.NEXT_PUBLIC_URL
 const PORT = process.env.NEXT_PUBLIC_PORT || 3000
+
+export function findClosestEtape(etapes) {
+  if (etapes.some(etape => etape.date_debut)) {
+    const now = new Date()
+
+    const filteredLaterSteps = etapes.filter(etape => new Date(etape.date_debut) <= now)
+    return maxBy(filteredLaterSteps, etape => new Date(etape.date_debut))
+  }
+
+  // When "Etapes" has no date, use last one
+  return etapes[etapes.length - 1]
+}
 
 function getBaseUrl() {
   if (PUBLIC_URL) {

--- a/server/projets.js
+++ b/server/projets.js
@@ -1,7 +1,7 @@
 import createError from 'http-errors'
-import {maxBy} from 'lodash-es'
 import {validateCreation, validateChanges} from '../lib/projets-validator.js'
 import {buildGeometryFromTerritoires, getTerritoiresProperties} from '../lib/territoires.js'
+import {findClosestEtape} from '../lib/suivi-pcrs.js'
 import mongo from './util/mongo.js'
 
 export function expandProjet(projet) {
@@ -75,9 +75,7 @@ export async function getProjetsGeojson() {
   const projets = await mongo.db.collection('projets').find().toArray()
 
   const projetsFeatures = await Promise.all(projets.map(async projet => {
-    const now = new Date()
-    const filteredEtapes = projet.etapes.filter(etape => new Date(etape.date_debut) <= now)
-    const closestPostStep = maxBy(filteredEtapes, etape => new Date(etape.date_debut))
+    const closestPostStep = findClosestEtape(projet.etapes)
 
     return {
       type: 'Feature',


### PR DESCRIPTION
Certains projets PCRS provenant des fichiers YAML, utilisés avant la mise en place de la base de données, ne possèdent pas de date sur le champ étapes.

La récente mise à jour de la gestion de date des étapes (PR #151) ayant modifié la façon d'afficher les étapes (affichage basé sur la date de l'étape au lieu du statut), les étapes des projets concernés étaient affichés en état "investigation" au lieu de "livré".

Cette PR ajoute une vérification de la présence des dates afin de déterminer quelle étape et couleur doivent être affichées dans le panneau latéral et sur la carte.

