### PR TITLE
Corrige un problème avec les projets futurs

### DIFF
--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -10,7 +10,11 @@ export function findClosestEtape(etapes) {
     const now = new Date()
 
     const filteredLaterSteps = etapes.filter(etape => new Date(etape.date_debut) <= now)
-    return maxBy(filteredLaterSteps, etape => new Date(etape.date_debut))
+    if (filteredLaterSteps.length > 0) {
+      return maxBy(filteredLaterSteps, etape => new Date(etape.date_debut))
+    }
+
+    return etapes[0]
   }
 
   // When "Etapes" has no date, use last one

--- a/server/projets.js
+++ b/server/projets.js
@@ -83,8 +83,8 @@ export async function getProjetsGeojson() {
       properties: {
         _id: projet._id,
         nom: projet.nom,
-        statut: closestPostStep.statut,
-        dateStatut: closestPostStep.date_debut,
+        statut: closestPostStep?.statut,
+        dateStatut: closestPostStep?.date_debut,
         aplc: projet.acteurs.find(acteur => acteur.role === 'aplc')?.nom || null,
         nature: projet.nature
       }


### PR DESCRIPTION
Cette PR corrige un bug qui fait planter l'application lorsqu'un projet en statut investigation possède une date postérieure à aujourd'hui.

