### PR TITLE
Correction du scroll vers l'erreur de périmètre

### DIFF
--- a/pages/formulaire-suivi/index.js
+++ b/pages/formulaire-suivi/index.js
@@ -74,7 +74,6 @@ const FormulaireSuivi = () => {
       }
 
       if (hasMissingData) {
-        console.log(1)
         setHasMissingDataOnValidation(true)
         handleScrollToError()
         setErrorOnValidationMessages([{message: 'Des données nécessaires à la validation du formulaires sont manquantes. Au moins un livrable, un acteur et un périmètre doivent être ajoutés.'}])
@@ -105,8 +104,8 @@ const FormulaireSuivi = () => {
           }, 2000)
         }
       }
-    } catch (error) {
-      console.log(error)
+    } catch {
+      setErrorOnValidationMessages('Une erreur a été rencontrée')
       throw new Error('Une erreur a été rencontrée')
     }
   }

--- a/pages/formulaire-suivi/index.js
+++ b/pages/formulaire-suivi/index.js
@@ -74,6 +74,7 @@ const FormulaireSuivi = () => {
       }
 
       if (hasMissingData) {
+        console.log(1)
         setHasMissingDataOnValidation(true)
         handleScrollToError()
         setErrorOnValidationMessages([{message: 'Des données nécessaires à la validation du formulaires sont manquantes. Au moins un livrable, un acteur et un périmètre doivent être ajoutés.'}])
@@ -104,7 +105,8 @@ const FormulaireSuivi = () => {
           }, 2000)
         }
       }
-    } catch {
+    } catch (error) {
+      console.log(error)
       throw new Error('Une erreur a été rencontrée')
     }
   }
@@ -156,7 +158,7 @@ const FormulaireSuivi = () => {
             />
           </div>
 
-          <div className='perimetres'>
+          <div id='perimetres'>
             <Perimetres
               perimetres={perimetres}
               handlePerimetres={setPerimetres}


### PR DESCRIPTION
Un `id` avait été oublié pour la section périmètre dans le formulaire de création de nouveau projet, bloquant le scroll vers l'erreur à la validation du formulaire