### PR TITLE
Désactiver les balises <a> lorsque les données sont indisponibles

### DIFF
--- a/components/map-sidebar/contact.js
+++ b/components/map-sidebar/contact.js
@@ -16,8 +16,8 @@ const Contact = ({name, phone, mail}) => (
     <div className='contact-info fr-grid-row fr-grid-row--middle'>
       <span aria-disabled className='fr-icon-phone-fill fr-col-1 fr-mr-1w fr-py-2w' aria-hidden='true' />
       <div className='fr-col-10 contact-data fr-py-2w fr-pl-2w fr-ml-1w'>
-        <a href={`tel:${phone}`} aria-label='Numéro de téléphone du contact de référence'>
-          {`${phone || 'non-renseigné'}`}
+        <a href={phone && `tel:${phone}`} aria-label='Numéro de téléphone du contact de référence'>
+          {phone || 'non renseigné'}
         </a>
       </div>
     </div>
@@ -26,7 +26,7 @@ const Contact = ({name, phone, mail}) => (
       <span aria-disabled className='fr-icon-mail-fill fr-col-1 fr-mr-1w' aria-hidden='true' />
       <div className='fr-col-10 contact-data fr-pl-2w fr-ml-1w'>
         <a
-          href={`mailto:${mail}`}
+          href={mail && `mailto:${mail}`}
           target='_self'
           aria-label='Email du contact de référence'
         >

--- a/components/map-sidebar/contact.js
+++ b/components/map-sidebar/contact.js
@@ -8,7 +8,7 @@ const Contact = ({name, phone, mail}) => (
       <span aria-disabled className='fr-icon-user-fill fr-col-1 fr-mr-1w' aria-hidden='true' />
       <div className='fr-col-10 contact-data fr-pl-2w fr-ml-1w'>
         <div aria-label='Nom du contact de référence'>
-          {`${name || 'non renseigné'}`}
+          {name || 'non renseigné'}
         </div>
       </div>
     </div>
@@ -30,7 +30,7 @@ const Contact = ({name, phone, mail}) => (
           target='_self'
           aria-label='Email du contact de référence'
         >
-          {`${mail || 'non renseigné'}`}
+          {mail || 'non renseigné'}
         </a>
       </div>
     </div>


### PR DESCRIPTION
Dans le panneau latéral de la carte, dans la partie "contacts", lorsqu'un des champs n'est pas renseigné, le message "non renseigné" était cliquable.
Comme la valeur était `null`, le navigateur essaye d'ouvrir 'null'.

C'est à présent `undefined` la valeur par défaut en cas d'absence de données. Le lien passe automatiquement en `disabled`

### **AVANT**
![lo](https://user-images.githubusercontent.com/66621960/232517060-9c09832d-1e08-4aed-a818-b9f884f38406.png)

------------------------------------------

### **APRÈS**
![Capture d’écran 2023-04-17 à 16 24 01](https://user-images.githubusercontent.com/66621960/232516983-b6749aac-1182-4b25-a786-219dd5c67a9a.png)

Close #164