### PR TITLE
Corrige l’affichage de "porteur" dans la popup de la carte

### DIFF
--- a/server/projets.js
+++ b/server/projets.js
@@ -85,7 +85,7 @@ export async function getProjetsGeojson() {
         nom: projet.nom,
         statut: closestPostStep?.statut,
         dateStatut: closestPostStep?.date_debut,
-        aplc: projet.acteurs.find(acteur => acteur.role === 'aplc')?.nom || null,
+        aplc: projet.acteurs.find(acteur => acteur.role === 'aplc' || acteur.role === 'porteur')?.nom || null,
         nature: projet.nature
       }
     }


### PR DESCRIPTION
Au survol de la carte, la popup n’affichait pas les porteurs "non-APLC" après la migration vers la version 0.3 du modèle de projet.

Cette PR ajoute le rôle de "porteur" dans les features de la carte, permettant de corriger ce problème.