### PR TITLE
Gérer le rôle des porteurs de projet dans le sélecteur

### DIFF
--- a/components/suivi-form/acteurs/index.js
+++ b/components/suivi-form/acteurs/index.js
@@ -182,10 +182,18 @@ const Acteurs = ({acteurs, handleActors, hasMissingData, onRequiredFormOpen}) =>
   }
 
   useEffect(() => {
-    // Disable APLC selector option when already selected
-    const hasAplc = acteurs.some(actor => actor.role === 'aplc')
-    rolesList.find(role => role.value === 'aplc').isDisabled = Boolean(hasAplc)
-  }, [acteurs])
+    // Enable aplc/porteur selector choices for editing aplc/porteur actor...
+    if (acteur.role === 'aplc' || acteur.role === 'porteur') {
+      rolesList.find(role => role.value === 'porteur').isDisabled = false
+      rolesList.find(role => role.value === 'aplc').isDisabled = false
+    } else {
+      const hasAplc = acteurs.some(actor => actor.role === 'aplc' || actor.role === 'porteur')
+
+      // ... disable aplc/porteur selector choices when actor with this role already exist
+      rolesList.find(role => role.value === 'aplc').isDisabled = Boolean(hasAplc)
+      rolesList.find(role => role.value === 'porteur').isDisabled = Boolean(hasAplc)
+    }
+  }, [acteur, acteurs])
 
   useEffect(() => {
     // Switch to actor update form


### PR DESCRIPTION
Lorsqu'un utilisateur choisissait le rôle d'un porteur de projet APLC pour un acteur, il lui était toujours possible de rajouter un acteur avec comme rôle porteur de projet non-aplc. Hors, un seul porteur de projet est autorisé.

Cette PR corrige ce problème en : 

- Permettant à l'utilisateur de modifier le rôle un acteur porteur de projet entre aplc/non-aplc
- Bloque le choix aplc/non-aplc pour les acteurs ajoutés si un de ces rôles est déjà associé à un acteur existant.

Acteur aplc/non-aplc ou acteur ajouté sans aucun porteur dans la liste des acteurs existants.
![Capture d’écran 2023-04-19 à 13 06 46](https://user-images.githubusercontent.com/66621960/233057262-afdef3ea-e2bc-427b-baff-8df6df5de6ff.png)

Nouvel acteur ajouté alors que le rôle de porteur aplc/non-aplc est déjà attribué
![Capture d’écran 2023-04-19 à 13 06 36](https://user-images.githubusercontent.com/66621960/233057273-66c473a2-1746-46e3-a5b5-73c63c901ec5.png)

