### PR TITLE
Ajout de routes permettant l'export de fichier CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Puis compléter les champs suivants :
 | `/projets/:id`| **DELETE** | *Supprime le projet demandé* |
 | `/projets/:id`| **PUT** | *Modifie le projet demandé* |
 | `/me`| **GET** | *Permet à un administrateur de s'authentifier après avoir fourni le jeton d'administration* |
-| `/data/projets.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des projets PCRS* |
+| `/data/projets.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des projets PCRS* **Option :** *`/?includesWkt=1` pour inclure les géométries des projets au format WKT* |
 | `/data/livrables.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des livrables des projets PCRS* |
 | `/data/tours-de-table.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des tours de table des projets PCRS* |
 | `/data/subventions.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des subventions des projets PCRS* |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Puis compléter les champs suivants :
 >*Les champs suivants sont optionnels, mais vous ne pourez pas accéder à la page `/blog` du site.*
 - `NEXT_PUBLIC_GHOST_URL` -> URL complète du blog Ghost (optionnel)
 - `GHOST_KEY` -> Jeton permettant l’accès aux articles du Blog Ghost (optionnel)
->*Pour utiliser l’API, vous devez compléter ce champ.*
+>*Pour utiliser l’API, vous devez compléter ce champ.*   
 >*En local, utilisez ce jeton pour authentifier les appels à l’API*
 - `API_ENTREPRISES_URL` -> URL de l’API "recherch-entreprises"
 - `MONGODB_URL` -> URL de la base de données MongoDB
@@ -69,8 +69,12 @@ Puis compléter les champs suivants :
 | `/projets`| **POST** | *Permet d’ajouter un projet PCRS* |
 | `/projets/:id`| **GET** | *Retourne le projet demandé* |
 | `/projets/:id`| **DELETE** | *Supprime le projet demandé* |
-  | `/projets/:id`| **PUT** | *Modifie le projet demandé* |
-  | `/me`| **GET** | *Permet à un administrateur de s'authentifier après avoir fourni le jeton d'administration* |
+| `/projets/:id`| **PUT** | *Modifie le projet demandé* |
+| `/me`| **GET** | *Permet à un administrateur de s'authentifier après avoir fourni le jeton d'administration* |
+| `/data/projets.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des projets PCRS* |
+| `/data/livrables.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des livrables des projets PCRS* |
+| `/data/tours-de-table.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des tours de table des projets PCRS* |
+| `/data/subventions.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des subventions des projets PCRS* |
 
 Vous pouvez accéder au modèle de données à [cette adresse](https://docs.pcrs.beta.gouv.fr/suivi-des-projets/modele-de-donnees).
 

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -46,15 +46,15 @@ export async function exportLivrablesAsCSV() {
       rows.push({
         refProjet: projet._id,
         nomProjet: projet.nom,
-        nom: livrable?.nom || '',
-        nature: livrable?.nature || '',
-        date_livraison: livrable?.date_livraison || '',
-        licence: livrable?.licence || '',
-        publication: livrable?.publication || '',
-        diffusion: livrable?.diffusion || '',
-        avancement: livrable?.avancement || '',
-        crs: livrable?.crs || '',
-        compression: livrable?.compression || ''
+        nom: livrable.nom || '',
+        nature: livrable.nature || '',
+        date_livraison: livrable.date_livraison || '',
+        licence: livrable.licence || '',
+        publication: livrable.publication || '',
+        diffusion: livrable.diffusion || '',
+        avancement: livrable.avancement || '',
+        crs: livrable.crs || '',
+        compression: livrable.compression || ''
       })
     }
   }
@@ -73,12 +73,12 @@ export async function exportToursDeTableAsCSV() {
         nomProjet: projet.nom,
         nomActeur: acteur.nom,
         sirenActeur: acteur.siren,
-        interlocuteur: acteur?.interlocuteur || '',
-        mail: acteur?.mail || '',
-        telephone: acteur?.telephone || '',
-        role: acteur?.role || '',
-        finance_part_perc: acteur?.finance_part_perc || '',
-        finance_part_euro: acteur?.finance_part_euro || ''
+        interlocuteur: acteur.interlocuteur || '',
+        mail: acteur.mail || '',
+        telephone: acteur.telephone || '',
+        role: acteur.role || '',
+        finance_part_perc: acteur.finance_part_perc || '',
+        finance_part_euro: acteur.finance_part_euro || ''
       })
     }
   }
@@ -98,8 +98,8 @@ export async function exportSubventionsAsCSV() {
           nomProjet: projet.nom,
           nom: subvention.nom,
           nature: subvention.nature,
-          montant: subvention?.montant || '',
-          echeance: subvention?.echeance || ''
+          montant: subvention.montant || '',
+          echeance: subvention.echeance || ''
         })
       }
     }

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 /* eslint-disable camelcase */
 import Papa from 'papaparse'
 import Wellknown from 'wellknown'
@@ -6,47 +5,36 @@ import Wellknown from 'wellknown'
 import {getProjets} from '../../server/projets.js'
 import {buildGeometryFromTerritoires} from '../../lib/territoires.js'
 
+async function computeWtk(perimetres) {
+  const perimetresGeojson = await buildGeometryFromTerritoires(perimetres)
+  return Wellknown.stringify(perimetresGeojson)
+}
+
 export async function exportProjetsAsCSV(includesWkt) {
   const projets = await getProjets()
-  const rows = []
 
-  if (includesWkt) {
-    for (const projet of projets) {
-      const perimetresGeojson = await buildGeometryFromTerritoires(projet.perimetres)
-      const wkt = Wellknown.stringify(perimetresGeojson)
+  const rows = await Promise.all(projets.map(async projet => {
+    const resultRows = ({
+      idProjet: projet._id,
+      nom: projet.nom,
+      regime: projet.regime,
+      nature: projet.nature,
+      statut: projet.etapes?.length > 0 ? projet.etapes[projet.etapes.length - 1]?.statut : '',
+      investigation_date: projet?.etapes?.find(e => e.statut === 'investigation')?.date_debut || '',
+      production_date: projet?.etapes?.find(e => e.statut === 'production')?.date_debut || '',
+      produit_date: projet?.etapes?.find(e => e.statut === 'produit')?.date_debut || '',
+      livre_date: projet?.etapes?.find(e => e.statut === 'livre')?.date_debut || '',
+      obsolete_date: projet?.etapes?.find(e => e.statut === 'obsolete')?.date_debut || ''
+    })
 
-      const projetsRows = {
-        idProjet: projet._id,
-        nom: projet.nom,
-        regime: projet.regime,
-        nature: projet.nature,
-        statut: projet.etapes?.length > 0 ? projet.etapes[projet.etapes.length - 1]?.statut : '',
-        investigation_date: projet?.etapes?.find(e => e.statut === 'investigation')?.date_debut || '',
-        production_date: projet?.etapes?.find(e => e.statut === 'production')?.date_debut || '',
-        produit_date: projet?.etapes?.find(e => e.statut === 'produit')?.date_debut || '',
-        livre_date: projet?.etapes?.find(e => e.statut === 'livre')?.date_debut || '',
-        obsolete_date: projet?.etapes?.find(e => e.statut === 'obsolete')?.date_debut || '',
-        geometrie: wkt
-      }
-
-      rows.push(projetsRows)
+    if (includesWkt) {
+      resultRows.geometrie = await computeWtk(projet.perimetres)
     }
 
-    return Papa.unparse(rows)
-  }
+    return resultRows
+  }))
 
-  return Papa.unparse(projets.map(projet => ({
-    idProjet: projet._id,
-    nom: projet.nom,
-    regime: projet.regime,
-    nature: projet.nature,
-    statut: projet.etapes?.length > 0 ? projet.etapes[projet.etapes.length - 1]?.statut : '',
-    investigation_date: projet?.etapes?.find(e => e.statut === 'investigation')?.date_debut || '',
-    production_date: projet?.etapes?.find(e => e.statut === 'production')?.date_debut || '',
-    produit_date: projet?.etapes?.find(e => e.statut === 'produit')?.date_debut || '',
-    livre_date: projet?.etapes?.find(e => e.statut === 'livre')?.date_debut || '',
-    obsolete_date: projet?.etapes?.find(e => e.statut === 'obsolete')?.date_debut || ''
-  })))
+  return Papa.unparse(rows)
 }
 
 export async function exportLivrablesAsCSV() {

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -67,20 +67,20 @@ export async function exportToursDeTableAsCSV() {
   const rows = []
 
   for (const projet of projets) {
-    const toursDeTableRows = projet.acteurs.map(acteur => ({
-      refProjet: projet._id,
-      nomProjet: projet.nom,
-      nomActeur: acteur?.nom,
-      sirenActeur: acteur?.siren,
-      interlocuteur: acteur?.interlocuteur || '',
-      mail: acteur?.mail || '',
-      telephone: acteur?.telephone || '',
-      role: acteur?.role || '',
-      finance_part_perc: acteur?.finance_part_perc || '',
-      finance_part_euro: acteur?.finance_part_euro || ''
-    }))
-
-    rows.push(...toursDeTableRows)
+    for (const acteur of projet.acteurs) {
+      rows.push({
+        refProjet: projet._id,
+        nomProjet: projet.nom,
+        nomActeur: acteur?.nom,
+        sirenActeur: acteur?.siren,
+        interlocuteur: acteur?.interlocuteur || '',
+        mail: acteur?.mail || '',
+        telephone: acteur?.telephone || '',
+        role: acteur?.role || '',
+        finance_part_perc: acteur?.finance_part_perc || '',
+        finance_part_euro: acteur?.finance_part_euro || ''
+      })
+    }
   }
 
   return Papa.unparse(rows)

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -92,16 +92,16 @@ export async function exportSubventionsAsCSV() {
 
   for (const projet of projets) {
     if (projet?.subventions) {
-      const subventionsRows = projet.subventions.map(subvention => ({
-        refProjet: projet._id,
-        nomProjet: projet.nom,
-        nom: subvention?.nom,
-        nature: subvention?.nature,
-        montant: subvention?.montant,
-        echeance: subvention?.echeance
-      }))
-
-      rows.push(...subventionsRows)
+      for (const subvention of projet.subventions) {
+        rows.push({
+          refProjet: projet._id,
+          nomProjet: projet.nom,
+          nom: subvention.nom,
+          nature: subvention.nature,
+          montant: subvention?.montant || '',
+          echeance: subvention?.echeance || ''
+        })
+      }
     }
   }
 

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -6,7 +6,7 @@ import Wellknown from 'wellknown'
 import {getProjets} from '../../server/projets.js'
 import {buildGeometryFromTerritoires} from '../../lib/territoires.js'
 
-export async function exportProjetAsCSV(includesWkt) {
+export async function exportProjetsAsCSV(includesWkt) {
   const projets = await getProjets()
   const rows = []
 

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -19,12 +19,12 @@ export async function exportProjetsAsCSV(includesWkt) {
       nom: projet.nom,
       regime: projet.regime,
       nature: projet.nature,
-      statut: projet.etapes?.length > 0 ? projet.etapes[projet.etapes.length - 1]?.statut : '',
-      investigation_date: projet?.etapes?.find(e => e.statut === 'investigation')?.date_debut || '',
-      production_date: projet?.etapes?.find(e => e.statut === 'production')?.date_debut || '',
-      produit_date: projet?.etapes?.find(e => e.statut === 'produit')?.date_debut || '',
-      livre_date: projet?.etapes?.find(e => e.statut === 'livre')?.date_debut || '',
-      obsolete_date: projet?.etapes?.find(e => e.statut === 'obsolete')?.date_debut || ''
+      statut: projet.etapes.length > 0 ? projet.etapes[projet.etapes.length - 1].statut : '',
+      investigation_date: projet.etapes.find(e => e.statut === 'investigation')?.date_debut || '',
+      production_date: projet.etapes.find(e => e.statut === 'production')?.date_debut || '',
+      produit_date: projet.etapes.find(e => e.statut === 'produit')?.date_debut || '',
+      livre_date: projet.etapes.find(e => e.statut === 'livre')?.date_debut || '',
+      obsolete_date: projet.etapes.find(e => e.statut === 'obsolete')?.date_debut || ''
     })
 
     if (includesWkt) {

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -71,8 +71,8 @@ export async function exportToursDeTableAsCSV() {
       rows.push({
         refProjet: projet._id,
         nomProjet: projet.nom,
-        nomActeur: acteur?.nom,
-        sirenActeur: acteur?.siren,
+        nomActeur: acteur.nom,
+        sirenActeur: acteur.siren,
         interlocuteur: acteur?.interlocuteur || '',
         mail: acteur?.mail || '',
         telephone: acteur?.telephone || '',

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -42,21 +42,21 @@ export async function exportLivrablesAsCSV() {
   const rows = []
 
   for (const projet of projets) {
-    const livrablesRows = projet.livrables.map(livrable => ({
-      refProjet: projet._id,
-      nomProjet: projet.nom,
-      nom: livrable?.nom || '',
-      nature: livrable?.nature || '',
-      date_livraison: livrable?.date_livraison || '',
-      licence: livrable?.licence || '',
-      publication: livrable?.publication || '',
-      diffusion: livrable?.diffusion || '',
-      avancement: livrable?.avancement || '',
-      crs: livrable?.crs || '',
-      compression: livrable?.compression || ''
-    }))
-
-    rows.push(...livrablesRows)
+    for (const livrable of projet.livrables) {
+      rows.push({
+        refProjet: projet._id,
+        nomProjet: projet.nom,
+        nom: livrable?.nom || '',
+        nature: livrable?.nature || '',
+        date_livraison: livrable?.date_livraison || '',
+        licence: livrable?.licence || '',
+        publication: livrable?.publication || '',
+        diffusion: livrable?.diffusion || '',
+        avancement: livrable?.avancement || '',
+        crs: livrable?.crs || '',
+        compression: livrable?.compression || ''
+      })
+    }
   }
 
   return Papa.unparse(rows)

--- a/lib/export/projet-csv.js
+++ b/lib/export/projet-csv.js
@@ -1,0 +1,93 @@
+/* eslint-disable camelcase */
+import Papa from 'papaparse'
+
+import {getProjets} from '../../server/projets.js'
+
+export async function exportProjetAsCSV() {
+  const projets = await getProjets()
+
+  return Papa.unparse(projets.map(projet => ({
+    idProjet: projet._id,
+    nom: projet.nom,
+    regime: projet.regime,
+    nature: projet.nature,
+    statut: projet.etapes?.length > 0 ? projet.etapes[projet.etapes.length - 1]?.statut : '',
+    investigation_date: projet?.etapes?.find(e => e.statut === 'investigation')?.date_debut || '',
+    production_date: projet?.etapes?.find(e => e.statut === 'production')?.date_debut || '',
+    produit_date: projet?.etapes?.find(e => e.statut === 'produit')?.date_debut || '',
+    livre_date: projet?.etapes?.find(e => e.statut === 'livre')?.date_debut || '',
+    obsolete_date: projet?.etapes?.find(e => e.statut === 'obsolete')?.date_debut || ''
+  })))
+}
+
+export async function exportLivrablesAsCSV() {
+  const projets = await getProjets()
+  const rows = []
+
+  for (const projet of projets) {
+    const livrablesRows = projet.livrables.map(livrable => ({
+      refProjet: projet._id,
+      nomProjet: projet.nom,
+      nom: livrable?.nom || '',
+      nature: livrable?.nature || '',
+      date_livraison: livrable?.date_livraison || '',
+      licence: livrable?.licence || '',
+      publication: livrable?.publication || '',
+      diffusion: livrable?.diffusion || '',
+      avancement: livrable?.avancement || '',
+      crs: livrable?.crs || '',
+      compression: livrable?.compression || ''
+    }))
+
+    rows.push(...livrablesRows)
+  }
+
+  return Papa.unparse(rows)
+}
+
+export async function exportToursDeTableAsCSV() {
+  const projets = await getProjets()
+  const rows = []
+
+  for (const projet of projets) {
+    const toursDeTableRows = projet.acteurs.map(acteur => ({
+      refProjet: projet._id,
+      nomProjet: projet.nom,
+      nomActeur: acteur?.nom,
+      sirenActeur: acteur?.siren,
+      interlocuteur: acteur?.interlocuteur || '',
+      mail: acteur?.mail || '',
+      telephone: acteur?.telephone || '',
+      role: acteur?.role || '',
+      finance_part_perc: acteur?.finance_part_perc || '',
+      finance_part_euro: acteur?.finance_part_euro || ''
+    }))
+
+    rows.push(...toursDeTableRows)
+  }
+
+  return Papa.unparse(rows)
+}
+
+export async function exportSubventionsAsCSV() {
+  const projets = await getProjets()
+  const rows = []
+
+  for (const projet of projets) {
+    if (projet?.subventions) {
+      const subventionsRows = projet.subventions.map(subvention => ({
+        refProjet: projet._id,
+        nomProjet: projet.nom,
+        nom: subvention?.nom,
+        nature: subvention?.nature,
+        montant: subvention?.montant,
+        echeance: subvention?.echeance
+      }))
+
+      rows.push(...subventionsRows)
+    }
+  }
+
+  return Papa.unparse(rows)
+}
+

--- a/lib/export/projet-csv.js
+++ b/lib/export/projet-csv.js
@@ -1,10 +1,39 @@
+/* eslint-disable no-await-in-loop */
 /* eslint-disable camelcase */
 import Papa from 'papaparse'
+import Wellknown from 'wellknown'
 
 import {getProjets} from '../../server/projets.js'
+import {buildGeometryFromTerritoires} from '../../lib/territoires.js'
 
-export async function exportProjetAsCSV() {
+export async function exportProjetAsCSV(includesWkt) {
   const projets = await getProjets()
+  const rows = []
+
+  if (includesWkt) {
+    for (const projet of projets) {
+      const perimetresGeojson = await buildGeometryFromTerritoires(projet.perimetres)
+      const wkt = Wellknown.stringify(perimetresGeojson)
+
+      const projetsRows = {
+        idProjet: projet._id,
+        nom: projet.nom,
+        regime: projet.regime,
+        nature: projet.nature,
+        statut: projet.etapes?.length > 0 ? projet.etapes[projet.etapes.length - 1]?.statut : '',
+        investigation_date: projet?.etapes?.find(e => e.statut === 'investigation')?.date_debut || '',
+        production_date: projet?.etapes?.find(e => e.statut === 'production')?.date_debut || '',
+        produit_date: projet?.etapes?.find(e => e.statut === 'produit')?.date_debut || '',
+        livre_date: projet?.etapes?.find(e => e.statut === 'livre')?.date_debut || '',
+        obsolete_date: projet?.etapes?.find(e => e.statut === 'obsolete')?.date_debut || '',
+        geometrie: wkt
+      }
+
+      rows.push(projetsRows)
+    }
+
+    return Papa.unparse(rows)
+  }
 
   return Papa.unparse(projets.map(projet => ({
     idProjet: projet._id,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mongodb": "^5.1.0",
     "morgan": "^1.10.0",
     "next": "^13.0.3",
+    "papaparse": "^5.4.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-autocomplete": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-autocomplete": "^1.8.1",
     "react-dom": "^18.2.0",
     "sharp": "^0.31.2",
-    "underscore.string": "^3.3.6"
+    "underscore.string": "^3.3.6",
+    "wellknown": "^0.5.0"
   },
   "devDependencies": {
     "ava": "^5.2.0",

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,7 @@ import errorHandler from './util/error-handler.js'
 import w from './util/w.js'
 
 import {getProjet, getProjets, createProjet, deleteProjet, updateProjet, getProjetsGeojson, expandProjet} from './projets.js'
+import {exportLivrablesAsCSV, exportProjetAsCSV, exportSubventionsAsCSV, exportToursDeTableAsCSV} from '../lib/export/projet-csv.js'
 
 const port = process.env.PORT || 3000
 const dev = process.env.NODE_ENV !== 'production'
@@ -101,6 +102,34 @@ server.route('/projets')
     const expandedProjet = expandProjet(projet)
 
     res.status(201).send(expandedProjet)
+  }))
+
+server.route('/data/projets.csv')
+  .get(w(async (req, res) => {
+    const projetsCSVFile = await exportProjetAsCSV()
+
+    res.attachment('projets.csv').type('csv').send(projetsCSVFile)
+  }))
+
+server.route('/data/livrables.csv')
+  .get(w(async (req, res) => {
+    const livrablesCSVFile = await exportLivrablesAsCSV()
+
+    res.attachment('livrables.csv').type('csv').send(livrablesCSVFile)
+  }))
+
+server.route('/data/tours-de-table.csv')
+  .get(w(async (req, res) => {
+    const toursDeTableCSVFile = await exportToursDeTableAsCSV()
+
+    res.attachment('tours-de-table.csv').type('csv').send(toursDeTableCSVFile)
+  }))
+
+server.route('/data/subventions.csv')
+  .get(w(async (req, res) => {
+    const subvensionsCSVFile = await exportSubventionsAsCSV()
+
+    res.attachment('subvensions.csv').type('csv').send(subvensionsCSVFile)
   }))
 
 server.route('/me')

--- a/server/index.js
+++ b/server/index.js
@@ -106,7 +106,7 @@ server.route('/projets')
 
 server.route('/data/projets.csv')
   .get(w(async (req, res) => {
-    const projetsCSVFile = await exportProjetsAsCSV(req.query.includesWkt)
+    const projetsCSVFile = await exportProjetsAsCSV(req.query.includesWkt === '1')
 
     res.attachment('projets.csv').type('csv').send(projetsCSVFile)
   }))

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,7 @@ import errorHandler from './util/error-handler.js'
 import w from './util/w.js'
 
 import {getProjet, getProjets, createProjet, deleteProjet, updateProjet, getProjetsGeojson, expandProjet} from './projets.js'
-import {exportLivrablesAsCSV, exportProjetAsCSV, exportSubventionsAsCSV, exportToursDeTableAsCSV} from '../lib/export/projet-csv.js'
+import {exportLivrablesAsCSV, exportProjetsAsCSV, exportSubventionsAsCSV, exportToursDeTableAsCSV} from '../lib/export/csv.js'
 
 const port = process.env.PORT || 3000
 const dev = process.env.NODE_ENV !== 'production'
@@ -106,7 +106,7 @@ server.route('/projets')
 
 server.route('/data/projets.csv')
   .get(w(async (req, res) => {
-    const projetsCSVFile = await exportProjetAsCSV(req.query.includesWkt)
+    const projetsCSVFile = await exportProjetsAsCSV(req.query.includesWkt)
 
     res.attachment('projets.csv').type('csv').send(projetsCSVFile)
   }))
@@ -127,9 +127,9 @@ server.route('/data/tours-de-table.csv')
 
 server.route('/data/subventions.csv')
   .get(w(async (req, res) => {
-    const subvensionsCSVFile = await exportSubventionsAsCSV()
+    const subventionsCSVFile = await exportSubventionsAsCSV()
 
-    res.attachment('subvensions.csv').type('csv').send(subvensionsCSVFile)
+    res.attachment('subventions.csv').type('csv').send(subventionsCSVFile)
   }))
 
 server.route('/me')

--- a/server/index.js
+++ b/server/index.js
@@ -106,7 +106,7 @@ server.route('/projets')
 
 server.route('/data/projets.csv')
   .get(w(async (req, res) => {
-    const projetsCSVFile = await exportProjetAsCSV()
+    const projetsCSVFile = await exportProjetAsCSV(req.query.includesWkt)
 
     res.attachment('projets.csv').type('csv').send(projetsCSVFile)
   }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,6 +1912,15 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+concat-stream@~1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
+  integrity sha512-H6xsIBfQ94aESBG8jGHXQ7i5AEpy5ZeVaLDOisDICiTCKpqEfr34/KmTrspKQNoLKNu9gTkovlpQcUi630AKiQ==
+  dependencies:
+    inherits "~2.0.1"
+    readable-stream "~2.0.0"
+    typedarray "~0.0.5"
+
 concordance@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/concordance/-/concordance-5.0.4.tgz#9896073261adced72f88d60e4d56f8efc4bbbbd2"
@@ -1962,6 +1971,11 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cosmiconfig@^7.0.1:
   version "7.0.1"
@@ -3343,7 +3357,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3659,6 +3673,11 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -4097,6 +4116,11 @@ minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
+minimist@~1.2.0:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minipass-collect@^1.0.2:
   version "1.0.2"
@@ -4845,6 +4869,11 @@ pretty-ms@^8.0.0:
   dependencies:
     parse-ms "^3.0.0"
 
+process-nextick-args@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+  integrity sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -5033,6 +5062,18 @@ readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-stream@~2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+  integrity sha512-TXcFfb63BQe1+ySzsHZI/5v1aJPCShfqvWJ64ayNImXMsN1Cd0YGk/wm8KB7/OeessgPc9QvS9Zou8QTkFzsLw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -5516,6 +5557,11 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -5809,6 +5855,11 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typedarray@~0.0.5:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.7.tgz#799207136a37f3b3efb8c66c40010d032714dc73"
+  integrity sha512-ueeb9YybpjhivjbHP2LdFDAjbS948fGEPj+ACAMs4xCMmh72OCOMQWBQKlaN4ZNQ04yfLSDLSx1tGRIoWimObQ==
+
 typescript@^4.7.3:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
@@ -5873,7 +5924,7 @@ use-sync-external-store@1.2.0:
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
-util-deprecate@^1.0.1, util-deprecate@^1.0.2:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
@@ -5944,6 +5995,14 @@ well-known-symbols@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/well-known-symbols/-/well-known-symbols-2.0.0.tgz#e9c7c07dbd132b7b84212c8174391ec1f9871ba5"
   integrity sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==
+
+wellknown@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/wellknown/-/wellknown-0.5.0.tgz#09ae9871fa826cf0a6ec1537ef00c379d78d7101"
+  integrity sha512-za5vTLuPF9nmrVOovYQwNEWE/PwJCM+yHMAj4xN1WWUvtq9OElsvKiPL0CR9rO8xhrYqL7NpI7IknqR8r6eYOg==
+  dependencies:
+    concat-stream "~1.5.0"
+    minimist "~1.2.0"
 
 whatwg-url@^11.0.0:
   version "11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4646,6 +4646,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+papaparse@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.4.1.tgz#f45c0f871853578bd3a30f92d96fdcfb6ebea127"
+  integrity sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"


### PR DESCRIPTION
Cette PR propose d’ajouter des routes permettant le téléchargement des données de suivi des PCRS au format CSV.
Les fichiers disponibles sont `projets.csv`, `livrables.csv`, `tours-de-tables.csv` et `subventions.csv`.

- Ajout de fonctions permettant la construction de fichier json et la conversion vers les champs attendus par le fichier CSV
- Ajout de route permettant de télécharger les données dans un fichier CSV

| Route | Type | Description |
|-------|------|-------------|
| `/data/projets.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des projets PCRS* |
| `/data/livrables.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des livrables des projets PCRS* |
| `/data/tours-de-table.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des tours de table des projets PCRS* |
| `/data/subventions.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des subventions des projets PCRS* |