### PR TITLE
Redirection vers la carte de suivi à la fermeture de la modale d'authentification

### DIFF
--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -41,7 +41,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
     setIsLoading(false)
   }, [])
 
-  const handleModal = () => router.push('/suivi-form')
+  const handleModal = () => router.push('/suivi-pcrs')
 
   const handleSubmit = async event => {
     event.preventDefault()

--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -1,4 +1,4 @@
-import {useState, useEffect, useCallback} from 'react'
+import {useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Image from 'next/image'
 import {useRouter} from 'next/router'
@@ -17,7 +17,6 @@ import Button from '@/components/button.js'
 const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subventions, etapes, _id}) => {
   const router = useRouter()
 
-  const [isAuthentificationModalOpen, setIsAuthentificationModalOpen] = useState(false)
   const [hasMissingDataOnValidation, setHasMissingDataOnValidation] = useState(false)
   const [validationMessage, setValidationMessage] = useState(null)
   const [errorOnValidationMessages, setErrorOnValidationMessages] = useState([])
@@ -42,7 +41,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
     setIsLoading(false)
   }, [])
 
-  const handleModal = useCallback(() => setIsAuthentificationModalOpen(!isAuthentificationModalOpen), [isAuthentificationModalOpen])
+  const handleModal = () => router.push('/suivi-form')
 
   const handleSubmit = async event => {
     event.preventDefault()


### PR DESCRIPTION
Lorsque l'utilisateur se retrouve sur la page `/formulaire-suivi` et souhaite refermer la modale d'authentification s'il ne dispose pas de token, le bouton de fermeture de la modale n'effectue aucune action visible au clic.

Cette PR permet de rediriger l'utilisateur vers la page de la carte des suivis.