### PR TITLE
Corrige l’erreur de conflit entre les noms de projet

### DIFF
--- a/server/projets.js
+++ b/server/projets.js
@@ -70,8 +70,12 @@ export async function updateProjet(id, payload) {
     }
 
     return value
-  } catch {
-    throw createError(410, 'Un projet avec le même nom est déjà existant, merci de modifier le champ "nom"')
+  } catch (error) {
+    if (error.codeName === 'DuplicateKey') {
+      throw createError(410, 'Un projet avec le même nom est déjà existant, merci de modifier le champ "nom"')
+    }
+
+    throw createError(500)
   }
 }
 

--- a/server/projets.js
+++ b/server/projets.js
@@ -75,7 +75,7 @@ export async function updateProjet(id, payload) {
       throw createError(410, 'Un projet avec le même nom est déjà existant, merci de modifier le champ "nom"')
     }
 
-    throw createError(500)
+    throw error
   }
 }
 

--- a/server/projets.js
+++ b/server/projets.js
@@ -58,17 +58,21 @@ export async function updateProjet(id, payload) {
     throw createError(400, 'Le contenu de la requête est invalide (aucun champ valide trouvé)')
   }
 
-  const {value} = await mongo.db.collection('projets').findOneAndUpdate(
-    {_id: mongo.parseObjectId(id)},
-    {$set: projet},
-    {returnDocument: 'after'}
-  )
+  try {
+    const {value} = await mongo.db.collection('projets').findOneAndUpdate(
+      {_id: mongo.parseObjectId(id)},
+      {$set: projet},
+      {returnDocument: 'after'}
+    )
 
-  if (!value) {
-    throw createError(404, 'Le projet est introuvable')
+    if (!value) {
+      throw createError(404, 'Le projet est introuvable')
+    }
+
+    return value
+  } catch {
+    throw createError(410, 'Un projet avec le même nom est déjà existant, merci de modifier le champ "nom"')
   }
-
-  return value
 }
 
 export async function getProjetsGeojson() {


### PR DESCRIPTION
Actuellement, lorsque l'utilisateur entre un nom de projet déjà présent dans la base de données, le formulaire renvoi une erreur 500 sans explication.

Cette PR ajoute un `try / catch` permettant de récupérer l'erreur envoyé par MongoDB et d'envoyer une erreur `409` ainsi qu'un message d'erreur explicite.

Fix #168 

### Capture : 

![image](https://user-images.githubusercontent.com/56537238/234624617-3b1b4268-5768-4c35-9746-f336cac5d611.png)
