### PR TITLE
Mise à jour de la bibliothèque DSFR

### DIFF
--- a/components/date-input.js
+++ b/components/date-input.js
@@ -8,7 +8,7 @@ const DateInput = ({label, value, ariaLabel, errorMessage, description, isRequir
       <label className='fr-label'>{label}</label>
       {description && <span className='fr-hint-text fr-mb-2w'>{description}</span>}
 
-      <div className='fr-input-wrap fr-fi-calendar-line'>
+      <div>
         <input
           className={`fr-input fr-input--${inputState}`}
           type='date'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@etalab/decoupage-administratif": "^2.3.1",
-    "@gouvfr/dsfr": "^1.8.1",
+    "@gouvfr/dsfr": "^1.9.2",
     "@keyv/sqlite": "^3.6.5",
     "@next/bundle-analyzer": "^13.0.7",
     "@turf/union": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,10 +783,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@gouvfr/dsfr@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@gouvfr/dsfr/-/dsfr-1.8.1.tgz#2484eb8ad9a73b5f01c5f41f49146d1aa8a71b7b"
-  integrity sha512-XpVFdvhtalA5jSAhzzNaMd+/Hvf8Ef9jCdAZhuukEEMo2/cWvCgzz9tfbE+9QTJDIVP+EwJ7aCGWcXUSWkOHJg==
+"@gouvfr/dsfr@^1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@gouvfr/dsfr/-/dsfr-1.9.2.tgz#b67852c4b62d1b0e0e1edbe5b6e16e4b6fc9aa41"
+  integrity sha512-uVo+z3xo2FFANa/cYdP2z21ieEXAeABKKrTE2FdKE8HXjhyh9tIcfsju8ux6nFA+pfBeOeUCwBXfOjPQD0eT5w==
 
 "@hapi/hoek@^9.0.0":
   version "9.3.0"


### PR DESCRIPTION
La mise à jour de la bibliothèque DSFR vers la version 1.9.2 corrige le problème d'icône calendrier sur les champs de type `date`


### **AVANT**
![Capture d’écran 2023-05-17 à 14 20 50](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/244055df-18ab-4bc6-8875-694b6dd7e987)


### **APRÈS**
![Capture d’écran 2023-05-17 à 14 20 39](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/29f3fb45-321f-405a-b70b-f32e626bce47)

Close #143