### PR TITLE
Problème d’affichage bouton de fermeture sous Safari

### DIFF
--- a/components/hidden-infos.js
+++ b/components/hidden-infos.js
@@ -4,32 +4,34 @@ import colors from '@/styles/colors.js'
 
 const HiddenInfos = ({theme, onClose, children}) => (
   <div className='hidden-infos-container fr-mt-1w'>
-    <button
-      type='button'
-      className='close-button'
-      title='Masquer l’information'
-      onClick={onClose}
-    >
-      <span className='fr-icon-close-line' aria-hidden='true' />
-    </button>
-    <div>
+    <div className='fr-grid-row fr-grid-row--right fr-pr-1w'>
+      <button
+        type='button'
+        className='close-button'
+        title='Masquer l’information'
+        onClick={onClose}
+      >
+        <span className='fr-icon-close-line' aria-hidden='true' />
+      </button>
+    </div>
+    <div className='content'>
       {children}
     </div>
 
     <style jsx>{`
-      .hidden-infos-container {
-        width: 100%;
+      .content {
         border: solid 2px ${theme === 'primary' ? colors.info425 : 'white'};
         padding: 10px;
-        position: relative;
         border-radius: 3px;
       }
 
+      .hidden-infos-container {
+        width: 100%;
+      }
+
       .close-button {
-        position: absolute;
-        top: -30px;
-        right: 10px;
         border: solid 2px ${theme === 'primary' ? colors.info425 : 'white'};
+        border-bottom-width: 0;
         border-radius: 3px 3px 0 0;
       }
 


### PR DESCRIPTION
Sous Safari, la bordure du bouton de fermeture du composant `<HiddenInfos />` n’était pas correctement alignée :

### **AVANT** 

<img width="275" alt="227866298-8dfb3e4b-1d3e-48b8-bf27-b4411afb3775" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/89e8ce56-1a0e-457b-858f-66f2aafc7aba">

### **APRÈS**
![Capture d’écran 2023-05-19 à 16 07 39](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/fb5f763a-f2fd-4c0b-ba5c-9a5806a97717)


Close #126