### PR TITLE
Amélioration de la suppression de projet

### DIFF
--- a/components/map-sidebar/project-header.js
+++ b/components/map-sidebar/project-header.js
@@ -2,16 +2,12 @@ import {useState, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 
-import {deleteSuivi} from '@/lib/suivi-pcrs.js'
-
 import colors from '@/styles/colors.js'
 
 import AuthentificationContext from '@/contexts/authentification-token.js'
 
 import HiddenInfos from '@/components/hidden-infos.js'
-import Button from '@/components/button.js'
-import Modal from '@/components/modal.js'
-import AuthentificationModal from '@/components/suivi-form/authentification-modal.js'
+import DeleteModal from '@/components/suivi-form/delete-modal.js'
 
 const Header = ({projectId, projectName, territoires, projets, onProjetChange}) => {
   const router = useRouter()
@@ -19,34 +15,10 @@ const Header = ({projectId, projectName, territoires, projets, onProjetChange}) 
 
   const [isTerritoiresShow, setIsTerritoiresShow] = useState(false)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
-  const [deleteValidationMessage, setDeleteValidationMessage] = useState(null)
-  const [deleteErrorMessage, setDeleteErrorMessage] = useState(null)
-  const [isAuthentificationModalOpen, setIsAuthentificationModalOpen] = useState(false)
 
   const hasToMuchTerritoires = territoires.length >= 4
 
   const handleDeleteModalOpen = () => setIsDeleteModalOpen(!isDeleteModalOpen)
-  const handleAuthentificationModal = () => setIsAuthentificationModalOpen(!isAuthentificationModalOpen)
-
-  const onDelete = async () => {
-    setDeleteValidationMessage(null)
-    setDeleteErrorMessage(null)
-
-    try {
-      if (isAdmin) {
-        await deleteSuivi(projectId, token)
-
-        setDeleteValidationMessage('le projet a bien été supprimé')
-        setTimeout(() => {
-          router.reload(window.location.pathname)
-        }, 2000)
-      } else {
-        handleAuthentificationModal()
-      }
-    } catch {
-      setDeleteErrorMessage('Impossible de supprimer ce projet')
-    }
-  }
 
   return (
     <div className='header'>
@@ -61,7 +33,7 @@ const Header = ({projectId, projectName, territoires, projets, onProjetChange}) 
                 aria-label='Editer le projet'
                 onClick={() => router.push(`/formulaire-suivi?id=${projectId}`)}
               >
-                <span className='fr-icon-edit-line ' aria-hidden='true' />
+                <span className='fr-icon-edit-line' aria-hidden='true' />
               </button>
 
               <button
@@ -76,35 +48,16 @@ const Header = ({projectId, projectName, territoires, projets, onProjetChange}) 
           )}
 
           {isDeleteModalOpen && (
-            <Modal title='Confirmer la suppression du projet' onClose={handleDeleteModalOpen}>
-              <p className='modal-content fr-mb-0'>Êtes-vous bien sûr de vouloir supprimer le suivi de <b>{projectName}</b> ? </p><br />
-              <p className='irreversible'><b>Cette action est irréversible</b></p>
-              <div className='fr-grid-row fr-grid-row--center'>
-                <Button
-                  label='Confirmer la suppression'
-                  isDisabled={Boolean(deleteValidationMessage)}
-                  onClick={() => onDelete()}
-                >
-                  Supprimer le projet
-                </Button>
-              </div>
-              {deleteValidationMessage && (
-                <p className='fr-grid-row fr-grid-row--center fr-valid-text fr-col-12 fr-mt-2w fr-mb-0'>
-                  {deleteValidationMessage}
-                </p>
-              )}
-
-              {deleteErrorMessage && (
-                <p className='fr-grid-row fr-grid-row--center fr-error-text fr-col-12 fr-mt-2w fr-mb-0'>
-                  {deleteErrorMessage}
-                </p>
-              )}
-            </Modal>
+            <DeleteModal
+              isSidebar
+              nom={projectName}
+              id={projectId}
+              token={token}
+              handleDeleteModalOpen={handleDeleteModalOpen}
+            />
           )}
         </div>
       </div>
-
-      {isAuthentificationModalOpen && <AuthentificationModal isAdmin={isAdmin} handleModalClose={handleAuthentificationModal} />}
 
       <div className='fr-text--lg fr-my-0'>Liste des territoires</div>
       {hasToMuchTerritoires ? (
@@ -143,6 +96,7 @@ const Header = ({projectId, projectName, territoires, projets, onProjetChange}) 
           </span>
         ))
       )}
+
       {projets && projets.length > 1 && (
         <div className='fr-select-group fr-p-3v fr-mt-3w' style={{borderTop: '1px solid white'}}>
           <label className='fr-label' style={{color: 'white'}}>Sélectionnez un autre projet</label>

--- a/components/suivi-form/delete-modal.js
+++ b/components/suivi-form/delete-modal.js
@@ -1,0 +1,93 @@
+import {useState} from 'react'
+import PropTypes from 'prop-types'
+import {useRouter} from 'next/router'
+
+import {deleteSuivi} from '@/lib/suivi-pcrs.js'
+
+import colors from '@/styles/colors.js'
+
+import Button from '@/components/button.js'
+import Modal from '@/components/modal.js'
+
+const DeleteModal = ({nom, id, token, isSidebar, handleDeleteModalOpen}) => {
+  const router = useRouter()
+
+  const [validationMessage, setValidationMessage] = useState(null)
+  const [errorMessage, setErrorMessage] = useState(null)
+
+  const onDelete = async () => {
+    setValidationMessage(null)
+    setErrorMessage(null)
+
+    try {
+      await deleteSuivi(id, token)
+
+      setValidationMessage('le projet a bien été supprimé')
+      setTimeout(() => {
+        if (isSidebar) {
+          router.reload(window.location.pathname)
+        } else {
+          router.push('/suivi-pcrs')
+        }
+      }, 2000)
+    } catch {
+      setErrorMessage('Impossible de supprimer ce projet')
+    }
+  }
+
+  return (
+    <Modal title='Confirmer la suppression du projet' onClose={handleDeleteModalOpen}>
+      <div className='modal-content fr-mt-5w'>
+        <p className='fr-text--lg'>Êtes-vous bien sûr de vouloir supprimer le suivi de <b>{nom}</b> ?</p><br />
+        <div className='fr-alert fr-alert--warning fr-alert--sm fr-mb-3w'>
+          <b className='irreversible-alert'>Cette action est irréversible</b>
+        </div>
+
+        <div className='fr-grid-row fr-grid-row--center'>
+          <Button
+            label='Confirmer la suppression'
+            isDisabled={Boolean(validationMessage)}
+            onClick={() => onDelete()}
+          >
+            Supprimer le projet
+          </Button>
+        </div>
+        {validationMessage && (
+          <p className='fr-grid-row fr-grid-row--center fr-valid-text fr-col-12 fr-mt-2w fr-mb-0'>
+            {validationMessage}
+          </p>
+        )}
+
+        {errorMessage && (
+          <p className='fr-grid-row fr-grid-row--center fr-error-text fr-col-12 fr-mt-2w fr-mb-0'>
+            {errorMessage}
+          </p>
+        )}
+      </div>
+
+      <style jsx>{`
+        .modal-content {
+          text-align: center;
+        }
+
+        .irreversible-alert {
+          color: ${colors.warningMain525};
+        }
+      `}</style>
+    </Modal>
+  )
+}
+
+DeleteModal.propTypes = {
+  nom: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  token: PropTypes.string.isRequired,
+  handleDeleteModalOpen: PropTypes.func.isRequired,
+  isSidebar: PropTypes.bool
+}
+
+DeleteModal.defaultProps = {
+  isSidebar: false
+}
+
+export default DeleteModal

--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -288,6 +288,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
             color: ${colors.redMarianne425};
             font-weight: bold;
             border: 1px solid ${colors.redMarianne425};
+            padding: .25rem .75rem;
           }
         `}</style>
     </>

--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import Image from 'next/image'
 import {useRouter} from 'next/router'
 
+import colors from '@/styles/colors.js'
+
 import {postSuivi, editProject} from '@/lib/suivi-pcrs.js'
 
 import {useInput} from '@/hooks/input.js'
@@ -10,6 +12,7 @@ import {useInput} from '@/hooks/input.js'
 import AuthentificationContext from '@/contexts/authentification-token.js'
 
 import AuthentificationModal from '@/components/suivi-form/authentification-modal.js'
+import DeleteModal from '@/components/suivi-form/delete-modal.js'
 import GeneralInfos from '@/components/suivi-form/general-infos.js'
 import Livrables from '@/components/suivi-form/livrables/index.js'
 import Acteurs from '@/components/suivi-form/acteurs/index.js'
@@ -26,6 +29,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
   const [validationMessage, setValidationMessage] = useState(null)
   const [errorMessage, setErrorMessage] = useState(null)
   const [isRequiredFormOpen, setIsRequiredFormOpen] = useState(false)
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const [suiviNom, setSuiviNom] = useInput({initialValue: nom})
   const [suiviNature, setSuiviNature] = useInput({initialValue: nature})
@@ -38,6 +42,8 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
   const [projetSubventions, setProjetSubventions] = useState(subventions || [])
 
   const hasMissingData = projetLivrables.length === 0 || projetActeurs.length === 0 || projetPerimetres.length === 0
+
+  const handleDeleteModalOpen = () => setIsDeleteModalOpen(!isDeleteModalOpen)
 
   useEffect(() => {
     if (!hasMissingData && !isRequiredFormOpen) {
@@ -125,17 +131,35 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
       <div className='fr-p-5w'>
         {(!token && !isTokenRecovering) && <AuthentificationModal handleModalClose={handleAuthentificationModal} />}
 
-        <Button
-          label='Retourner à la carte de suivi'
-          iconSide='left'
-          buttonStyle='secondary'
-          icon='arrow-left-line'
-          type='button'
-          size='sm'
-          onClick={() => router.push('/suivi-pcrs')}
-        >
-          Retourner à la carte de suivi
-        </Button>
+        <div className='fr-grid-row fr-col-12'>
+          <div className='fr-grid-row fr-grid-row--left fr-col-12 fr-col-md-10'>
+            <Button
+              label='Retourner à la carte de suivi'
+              iconSide='left'
+              buttonStyle='secondary'
+              icon='arrow-left-line'
+              type='button'
+              size='sm'
+              onClick={() => router.push('/suivi-pcrs')}
+            >
+              Retourner à la carte de suivi
+            </Button>
+          </div>
+
+          {_id && (
+            <div className='fr-grid-row fr-grid-row--left fr-col-12 fr-col-md-2 fr-mt-3w fr-mt-md-0'>
+              <button
+                type='button'
+                aria-label='Supprimer le projet'
+                icon='delete-line'
+                className='delete-button'
+                onClick={handleDeleteModalOpen}
+              >
+                <span className='fr-icon-delete-fill fr-icon--sm fr-mr-1w' aria-hidden='true' />Supprimer le projet
+              </button>
+            </div>
+          )}
+        </div>
 
         <p className='required-disclaimer fr-mt-3w'>Les champs indiqués par une * sont obligatoires</p>
 
@@ -182,23 +206,39 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
 
           <Subventions subventions={projetSubventions} handleSubventions={setProjetSubventions} />
 
-          <div className='fr-grid-row fr-grid-row--center fr-grid-row--gutters fr-mt-12w'>
-            <div className='fr-grid-row fr-col-12 fr-grid-row--center'>
-              <div className='fr-grid-row fr-py-2w fr-px-1w fr-px-md-6w'>
-                <Button
-                  label='Retourner à la carte de suivi'
-                  iconSide='left'
-                  buttonStyle='secondary'
-                  icon='arrow-left-line'
-                  type='button'
-                  size='sm'
-                  onClick={() => router.push('/suivi-pcrs')}
-                >
-                  Retourner à la carte de suivi
-                </Button>
+          <div className='fr-grid-row fr-grid-row--center  fr-grid-row--gutters fr-mt-2w'>
+            <div className='fr-grid-row fr-mt-12w fr-col-12'>
+              <div className='fr-grid-row fr-col-12'>
+                <div className='fr-grid-row fr-grid-row--left fr-col-12 fr-col-md-10'>
+                  <Button
+                    label='Retourner à la carte de suivi'
+                    iconSide='left'
+                    buttonStyle='secondary'
+                    icon='arrow-left-line'
+                    type='button'
+                    size='sm'
+                    onClick={() => router.push('/suivi-pcrs')}
+                  >
+                    Retourner à la carte de suivi
+                  </Button>
+                </div>
+
+                {_id && (
+                  <div className='fr-grid-row fr-grid-row--left fr-col-12 fr-col-md-2 fr-mt-3w fr-mt-md-0'>
+                    <button
+                      type='button'
+                      aria-label='Supprimer le projet'
+                      icon='delete-line'
+                      className='delete-button'
+                      onClick={handleDeleteModalOpen}
+                    >
+                      <span className='fr-icon-delete-fill fr-icon--sm fr-mr-1w' aria-hidden='true' />Supprimer le projet
+                    </button>
+                  </div>
+                )}
               </div>
 
-              <div className='fr-grid-row fr-py-2w fr-px-1w fr-px-md-6w'>
+              <div className='fr-grid-row fr-grid-row--center fr-mt-10w fr-col-12'>
                 <Button
                   label='Valider le formulaire'
                   icon='checkbox-circle-fill'
@@ -210,6 +250,15 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
                 </Button>
               </div>
             </div>
+
+            {isDeleteModalOpen && (
+              <DeleteModal
+                nom={nom}
+                id={_id}
+                token={token}
+                handleDeleteModalOpen={handleDeleteModalOpen}
+              />
+            )}
 
             {validationMessage && (
               <p className='fr-grid-row fr-grid-row--center fr-valid-text fr-col-12 fr-col-md-6 fr-mb-0'>
@@ -227,14 +276,20 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
       </div>
 
       <style jsx>{`
-        .form-header {
-          text-align: center;
-        }
+          .form-header {
+            text-align: center;
+          }
 
-        .required-disclaimer {
-          font-style: italic;
-        }
-      `}</style>
+          .required-disclaimer {
+            font-style: italic;
+          }
+
+          .delete-button {
+            color: ${colors.redMarianne425};
+            font-weight: bold;
+            border: 1px solid ${colors.redMarianne425};
+          }
+        `}</style>
     </>
   )
 }

--- a/styles/colors.js
+++ b/styles/colors.js
@@ -17,9 +17,6 @@ export default ({
   info425: '#0063cb',
   blueHover: '#1212FF',
 
-  // Green
-  success425: '#18753C',
-
   // Orange
   warningMain525: '#d64d00',
 

--- a/styles/colors.js
+++ b/styles/colors.js
@@ -17,6 +17,12 @@ export default ({
   info425: '#0063cb',
   blueHover: '#1212FF',
 
+  // Green
+  success425: '#18753C',
+
+  // Orange
+  warningMain525: '#d64d00',
+
   // Red
   error425: '#CE0500',
   redMarianne425: '#c9191e'


### PR DESCRIPTION
Cette PR ajoute : 

- Des boutons de suppression de projet lorsque l'utilisateur est sur la page du formulaire en mode édition
- Un composant réutilisable `<DeleteModal />`, utilisé dans l'entête du projet dans la carte de suivi et dans la page du formulaire en mode édition. Ce composant reprend la structure de la modale de suppression déjà existante dans l'entête du projet et son design a bénéficié d'une amélioration.

### **BOUTONS ÉDITION DU FORMULAIRE**
![Capture d’écran 2023-05-23 à 11 38 18](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/14a8fedb-9bfa-4329-8227-a0ce7437896b)
![Capture d’écran 2023-05-23 à 11 38 09](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/5d72c679-1892-4016-8dcf-843f93cd3223)

----------------------------------
### **MODALE**
![Capture d’écran 2023-05-23 à 11 43 40](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/f085537b-43ba-469e-bcf1-4746654267ff)

