### PR TITLE
Corrige le problème d'index `null` dans MongoDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "NODE_ENV=production node server/index.js",
     "lint": "xo",
     "test": "ava",
-    "scalingo-postbuild": "yarn download-contours && next build"
+    "scalingo-postbuild": "node scripts/add-editor-key.js && yarn download-contours && next build"
   },
   "dependencies": {
     "@etalab/decoupage-administratif": "^2.3.1",

--- a/server/util/mongo.js
+++ b/server/util/mongo.js
@@ -22,7 +22,7 @@ class Mongo {
 
   async createIndexes() {
     await this.db.collection('projets').createIndex({nom: 1}, {unique: true})
-    await this.db.collection('projets').createIndex({editorKey: 1}, {unique: true})
+    await this.db.collection('projets').createIndex({editorKey: 1}, {unique: true, sparse: true})
     await this.db.collection('creators').createIndex({token: 1}, {unique: true, sparse: true})
     await this.db.collection('creators').createIndex({createdAt: 1}, {expireAfterSeconds: 86400}) // 24 heures
   }


### PR DESCRIPTION
Cette PR ajoute l'option `sparse` sur l'index Mongo `editorKey` 