### PR TITLE
Ajout d'une route `/data/editor-keys.csv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Puis compléter les champs suivants :
 | `/data/livrables.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des livrables des projets PCRS* |
 | `/data/tours-de-table.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des tours de table des projets PCRS* |
 | `/data/subventions.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des subventions des projets PCRS* |
+| `/data/editor-keys.csv`| **GET** | *Retourne l’ensemble des codes d’édition des projets (Cette route est réservée aux administrateurs)* |
 | `/ask-code`| **POST** | *Faire une demande de création de projet. Cette route attend un objet `{"email": email du demandeur}`* |
 | `/check-code`| **POST** | *Vérifie la validité du code envoyé par email. Cette route attend un objet `{"email": email du demandeur, "pinCode": code envoyé par mail}`* |
 

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -110,15 +110,11 @@ export async function exportSubventionsAsCSV() {
 
 export async function exportEditorKeys() {
   const projets = await getProjets()
-  const rows = []
-
-  for (const projet of projets) {
-    rows.push({
-      nomProjet: projet.nom,
-      refProjet: projet._id,
-      editorKey: projet.editorKey
-    })
-  }
+  const rows = projets.map(projet => ({
+    nomProjet: projet.nom,
+    refProjet: projet._id,
+    editorKey: projet.editorKey
+  }))
 
   return Papa.unparse(rows)
 }

--- a/lib/export/csv.js
+++ b/lib/export/csv.js
@@ -108,3 +108,17 @@ export async function exportSubventionsAsCSV() {
   return Papa.unparse(rows)
 }
 
+export async function exportEditorKeys() {
+  const projets = await getProjets()
+  const rows = []
+
+  for (const projet of projets) {
+    rows.push({
+      nomProjet: projet.nom,
+      refProjet: projet._id,
+      editorKey: projet.editorKey
+    })
+  }
+
+  return Papa.unparse(rows)
+}

--- a/server/auth/middleware.js
+++ b/server/auth/middleware.js
@@ -83,3 +83,11 @@ export function ensureCreator(req, res, next) {
 
   throw createError(403, 'Vous n’êtes pas autorisé à créer un projet')
 }
+
+export function ensureAdmin(req, res, next) {
+  if (req.role === 'admin') {
+    return next()
+  }
+
+  throw createError(403, 'Vous n’êtes pas autorisé à accéder à cette information')
+}

--- a/server/index.js
+++ b/server/index.js
@@ -18,11 +18,11 @@ import mongo from './util/mongo.js'
 import errorHandler from './util/error-handler.js'
 import w from './util/w.js'
 
-import {handleAuth, ensureCreator, ensureProjectEditor} from './auth/middleware.js'
+import {handleAuth, ensureCreator, ensureProjectEditor, ensureAdmin} from './auth/middleware.js'
 import {sendPinCodeEmail, checkPinCodeValidity, isAuthorizedEmail} from './auth/pin-code/index.js'
 
 import {getProjet, getProjets, deleteProjet, updateProjet, getProjetsGeojson, expandProjet, filterSensitiveFields, createProjet} from './projets.js'
-import {exportLivrablesAsCSV, exportProjetsAsCSV, exportSubventionsAsCSV, exportToursDeTableAsCSV} from '../lib/export/csv.js'
+import {exportEditorKeys, exportLivrablesAsCSV, exportProjetsAsCSV, exportSubventionsAsCSV, exportToursDeTableAsCSV} from '../lib/export/csv.js'
 
 const port = process.env.PORT || 3000
 const dev = process.env.NODE_ENV !== 'production'
@@ -125,6 +125,13 @@ server.route('/data/subventions.csv')
     const subventionsCSVFile = await exportSubventionsAsCSV()
 
     res.attachment('subventions.csv').type('csv').send(subventionsCSVFile)
+  }))
+
+server.route('/data/editor-keys.csv')
+  .get(w(ensureAdmin), w(async (req, res) => {
+    const editorKeysCSVFile = await exportEditorKeys()
+
+    res.attachment('editor-keys.csv').type('csv').send(editorKeysCSVFile)
   }))
 
 server.route('/ask-code')


### PR DESCRIPTION
Cette PR ajoute une route permettant aux administrateurs de récupérer l'ensemble des codes d'édition des projets dans un fichier CSV.

- Ajoute une fonction qui crée le fichier CSV
- Ajoute un middleware pour autoriser uniquement les administrateurs
- Ajoute une route pour récupérer le fichier CSV
- Mise à jour de la documentation

