### PR TITLE
Traitement des erreurs de payload

### DIFF
--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -2,6 +2,9 @@ import {useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Image from 'next/image'
 import {useRouter} from 'next/router'
+import {uniq, sortBy} from 'lodash'
+
+import {PAYLOAD_ERRORS} from './utils/payload-errors.js'
 
 import {postSuivi, editProject} from '@/lib/suivi-pcrs.js'
 
@@ -26,6 +29,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
   const [hasMissingItemsOnValidation, setHasMissingItemsOnValidation] = useState(false)
   const [validationMessage, setValidationMessage] = useState(null)
   const [errorMessage, setErrorMessage] = useState(null)
+  const [errors, setErrors] = useState([])
   const [isRequiredFormOpen, setIsRequiredFormOpen] = useState(false)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
@@ -100,7 +104,20 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
 
         if (sendSuivi.message) {
           if (sendSuivi.message === 'Invalid payload') {
-            sendSuivi.message = 'Le projet n’a pas pu être pris en compte car il y a des erreurs'
+            const payloadErrors = []
+            sendSuivi.message = ('Le projet n’a pas pu être pris en compte car il y a des erreurs :')
+
+            const sortedErrors = sortBy(sendSuivi.validationErrors, error => error.context.key)
+            sortedErrors.map(error => {
+              let message
+              if (PAYLOAD_ERRORS[error.context.key]) {
+                message = `Section ${error.path[0]} - ${PAYLOAD_ERRORS[error.context.key]} ${error.context.value ? `: ${error.context.value}` : ''}`
+              }
+
+              return payloadErrors.push(message)
+            })
+
+            setErrors(uniq(payloadErrors))
           }
 
           setErrorMessage(sendSuivi.message)
@@ -276,9 +293,15 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
             )}
 
             {errorMessage && (
-              <p className='fr-grid-row--center fr-error-text fr-col-12 fr-mt-2w fr-mb-0'>
-                {errorMessage}
-              </p>
+              <div>
+                <p className='fr-grid-row--center fr-error-text fr-text--sm fr-col-12 fr-mt-2w fr-mb-0'>
+                  {errorMessage}
+                </p>
+
+                <ul>
+                  {errors.map(error => <li key={error} className='fr-text--sm error-list'>{error}</li>)}
+                </ul>
+              </div>
             )}
           </div>
         </form>
@@ -306,6 +329,11 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
           color: ${colors.redMarianne425};
           font-weight: bold;
           border: 1px solid ${colors.redMarianne425};
+        }
+
+        .error-list {
+          color: ${colors.error425};
+          list-style-type: disc;
         }
       `}</style>
     </>

--- a/components/suivi-form/utils/payload-errors.js
+++ b/components/suivi-form/utils/payload-errors.js
@@ -1,0 +1,17 @@
+/* eslint-disable camelcase */
+
+export const PAYLOAD_ERRORS = {
+  // Général
+  nom: 'Un nom est manquant',
+  nature: 'La nature n’a pas été sélectionné',
+  // Livrables
+  licence: 'Un type de licence n’a pas été sélectionné',
+  avancement: 'Un pourcentage de progression de l’avancement suivant est invalide',
+  // Acteurs
+  mail: 'l’email suivant est invalide',
+  telephone: 'Le numéro de téléphone suivant est invalide',
+  finance_part_euro: 'La part de financement suivante est invalide',
+  finance_part_perc: 'Le montant du financement suivant est invalide',
+  siren: 'Un numéro SIREN est manquant ou invalide',
+  role: 'Un rôle n’a pas été sélectionnée'
+}

--- a/components/suivi-form/utils/payload-errors.js
+++ b/components/suivi-form/utils/payload-errors.js
@@ -3,12 +3,12 @@
 export const PAYLOAD_ERRORS = {
   // Général
   nom: 'Un nom est manquant',
-  nature: 'La nature n’a pas été sélectionné',
+  nature: 'La nature n’a pas été sélectionnée',
   // Livrables
   licence: 'Un type de licence n’a pas été sélectionné',
-  avancement: 'Un pourcentage de progression de l’avancement suivant est invalide',
+  avancement: 'Un pourcentage de progression de l’avancement est invalide',
   // Acteurs
-  mail: 'l’email suivant est invalide',
+  mail: 'L’email suivant est invalide',
   telephone: 'Le numéro de téléphone suivant est invalide',
   finance_part_euro: 'La part de financement suivante est invalide',
   finance_part_perc: 'Le montant du financement suivant est invalide',


### PR DESCRIPTION
Les erreurs concernant les champs problématiques renvoyés par l'API n'étaient pas traitées. Seule une erreur générale s'affichait, sans plus de précision.

Les erreurs principales sont interprétées afin d'apporter plus de clarté sur la cause de l'erreur d'envoi du formulaire. 

![Capture d’écran 2023-05-26 à 12 27 26](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/f2431320-da1c-4ece-89a8-43c8b3c57f90)
