### PR TITLE
Ajout d’une route administrateur pour renouveler la clé d’édition d’un projet

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,7 @@ import w from './util/w.js'
 import {handleAuth, ensureCreator, ensureProjectEditor, ensureAdmin} from './auth/middleware.js'
 import {sendPinCodeEmail, checkPinCodeValidity, isAuthorizedEmail} from './auth/pin-code/index.js'
 
-import {getProjet, getProjets, deleteProjet, updateProjet, getProjetsGeojson, expandProjet, filterSensitiveFields, createProjet} from './projets.js'
+import {getProjet, getProjets, deleteProjet, updateProjet, getProjetsGeojson, expandProjet, filterSensitiveFields, createProjet, renewEditorKey} from './projets.js'
 import {exportEditorKeys, exportLivrablesAsCSV, exportProjetsAsCSV, exportSubventionsAsCSV, exportToursDeTableAsCSV} from '../lib/export/csv.js'
 
 const port = process.env.PORT || 3000
@@ -161,6 +161,13 @@ server.route('/me')
     }
 
     res.send({role: req.role})
+  }))
+
+server.route('/renew-editor-key')
+  .post(w(ensureAdmin), w(async (req, res) => {
+    await renewEditorKey(req.body.projetId)
+
+    res.status(200).send()
   }))
 
 server.use(errorHandler)

--- a/server/projets.js
+++ b/server/projets.js
@@ -20,10 +20,16 @@ function computeEditorKey() {
 }
 
 export async function renewEditorKey(projetId) {
-  await mongo.db.collection('projets').updateOne(
+  projetId = mongo.parseObjectId(projetId)
+
+  const {modifiedCount} = await mongo.db.collection('projets').updateOne(
     {_id: projetId},
     {$set: {editorKey: computeEditorKey()}}
   )
+
+  if (!modifiedCount) {
+    throw createError(304, 'Le code d’édition n’a pas été renouvellé')
+  }
 }
 
 export function filterSensitiveFields(projet) {


### PR DESCRIPTION
Cette PR ajoute une route, réservée aux administrateurs, qui permet de renouveler le code d’édition d’un projet.

- Adaptation de la fonction `renewEditorKey` 
- Ajout d'une route `/renew-editiorkey`