### PR TITLE
Ajoute une collection des mails autorisés à créer des projets PCRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Puis compléter les champs suivants :
 | `/data/editor-keys.csv`| **GET** | *Retourne l’ensemble des codes d’édition des projets (Cette route est réservée aux administrateurs)* |
 | `/ask-code`| **POST** | *Faire une demande de création de projet. Cette route attend un objet `{"email": email du demandeur}`* |
 | `/check-code`| **POST** | *Vérifie la validité du code envoyé par email. Cette route attend un objet `{"email": email du demandeur, "pinCode": code envoyé par mail}`* |
+| `/creator-emails`| **GET** | *Retourne l’ensemble des emails autorisés à créer un projet (Cette route est réservée aux administrateurs)* |
+| `/creator-emails`| **POST** | *Permet d’ajouter un email autorisé à créer un projet (Cette route est réservée aux administrateurs)* |
+| `/creator-emails/:id`| **GET** | *Retourne les informations d’un mail autorisé à créer un projet (Cette route est réservée aux administrateurs)* |
+| `/creator-emails/:id`| **DELETE** | *Supprime le mail (Cette route est réservée aux administrateurs)* |
+| `/creator-emails/:id`| **PUT** | *Permet de modifier le mail ou le nom (Cette route est réservée aux administrateurs)* |
 
 Vous pouvez accéder au modèle de données à [cette adresse](https://docs.pcrs.beta.gouv.fr/suivi-des-projets/modele-de-donnees).
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "NODE_ENV=production node server/index.js",
     "lint": "xo",
     "test": "ava",
-    "scalingo-postbuild": "yarn download-contours && node scripts/add-editor-key.js && next build"
+    "scalingo-postbuild": "yarn download-contours && node scripts/authorized-creators-emails.js && next build"
   },
   "dependencies": {
     "@etalab/decoupage-administratif": "^2.3.1",

--- a/scripts/authorized-creators-emails.js
+++ b/scripts/authorized-creators-emails.js
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
+/* eslint-disable import/first */
 /* eslint-disable no-await-in-loop */
+
+import * as dotenv from 'dotenv'
+
+dotenv.config()
 
 import mongo from '../server/util/mongo.js'
 import {getAuthorizedEmails, validateEmail} from '../server/auth/pin-code/index.js'

--- a/scripts/authorized-creators-emails.js
+++ b/scripts/authorized-creators-emails.js
@@ -19,7 +19,7 @@ for (const email of emails) {
 
     mongo.decorateCreation(creator)
 
-    await mongo.db.collection('creators-emails').updateOne({email: creator.email}, {$setOnInsert: {...creator}}, {upsert: true})
+    await mongo.db.collection('creators-emails').updateOne({email: creator.email}, {$setOnInsert: creator}, {upsert: true})
   }
 }
 

--- a/scripts/authorized-creators-emails.js
+++ b/scripts/authorized-creators-emails.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/* eslint-disable no-await-in-loop */
+
+import mongo from '../server/util/mongo.js'
+import {getAuthorizedEmails, validateEmail} from '../server/auth/pin-code/index.js'
+
+await mongo.connect()
+
+const emails = await getAuthorizedEmails()
+
+for (const email of emails) {
+  if (validateEmail(email)) {
+    const creator = {email}
+
+    mongo.decorateCreation(creator)
+
+    await mongo.db.collection('creators-emails').updateOne({email: creator.email}, {$setOnInsert: {...creator}}, {upsert: true})
+  }
+}
+
+console.log('Terminé !')
+
+await mongo.disconnect()

--- a/server/admin/creators-emails.js
+++ b/server/admin/creators-emails.js
@@ -1,4 +1,5 @@
 import createError from 'http-errors'
+import {pick} from 'lodash-es'
 import {validateEmail} from '../auth/pin-code/index.js'
 import mongo from '../util/mongo.js'
 
@@ -45,11 +46,13 @@ export async function addCreator(creator) {
 export async function updateCreator(creatorId, update) {
   creatorId = mongo.parseObjectId(creatorId)
 
-  mongo.decorateUpdate(update)
+  const changes = pick(update, ['email', 'nom'])
+
+  mongo.decorateUpdate(changes)
 
   const {value} = await mongo.db.collection('creators-emails').findOneAndUpdate(
     {_id: creatorId},
-    {$set: {...update}},
+    {$set: {...changes}},
     {returnDocument: 'after'}
   )
 

--- a/server/admin/creators-emails.js
+++ b/server/admin/creators-emails.js
@@ -1,0 +1,72 @@
+import createError from 'http-errors'
+import {validateEmail} from '../auth/pin-code/index.js'
+import mongo from '../util/mongo.js'
+
+export async function getCreators() {
+  return mongo.db.collection('creators-emails').find().toArray()
+}
+
+export async function getCreatorByEmail(email) {
+  const foundEmail = await mongo.db.collection('creators-emails').findOne({email})
+
+  return foundEmail
+}
+
+export async function getCreatorById(creatorId) {
+  creatorId = mongo.parseObjectId(creatorId)
+
+  const creator = await mongo.db.collection('creators-emails').findOne({_id: creatorId})
+
+  if (!creator) {
+    throw createError(404, 'Cette adresse courriel est introuvable')
+  }
+
+  return creator
+}
+
+export async function addCreator(creator) {
+  if (!validateEmail(creator.email)) {
+    throw createError(400, 'Cette adresse courriel est invalide')
+  }
+
+  mongo.decorateCreation(creator)
+
+  try {
+    await mongo.db.collection('creators-emails').insertOne(creator)
+  } catch (error) {
+    if (error.message.includes('E11000')) {
+      throw createError(409, 'Cet adresse est déjà dans la liste.')
+    }
+
+    throw error
+  }
+
+  return creator
+}
+
+export async function updateCreator(creatorId, update) {
+  creatorId = mongo.parseObjectId(creatorId)
+
+  mongo.decorateUpdate(update)
+
+  const {value} = await mongo.db.collection('creators-emails').findOneAndUpdate(
+    {_id: creatorId},
+    {$set: {...update}},
+    {returnDocument: 'after'}
+  )
+
+  if (!value) {
+    throw createError(404, 'Cette adresse est introuvable')
+  }
+
+  return value
+}
+
+export async function deleteCreator(creatorId) {
+  creatorId = mongo.parseObjectId(creatorId)
+
+  const deleted = await mongo.db.collection('creators-emails').deleteOne({_id: creatorId})
+
+  return deleted
+}
+

--- a/server/admin/creators-emails.js
+++ b/server/admin/creators-emails.js
@@ -65,6 +65,6 @@ export async function deleteCreator(creatorId) {
 
   const deleted = await mongo.db.collection('creators-emails').deleteOne({_id: creatorId})
 
-  return deleted
+  return Boolean(deleted)
 }
 

--- a/server/admin/creators-emails.js
+++ b/server/admin/creators-emails.js
@@ -7,9 +7,7 @@ export async function getCreators() {
 }
 
 export async function getCreatorByEmail(email) {
-  const foundEmail = await mongo.db.collection('creators-emails').findOne({email})
-
-  return foundEmail
+  return mongo.db.collection('creators-emails').findOne({email})
 }
 
 export async function getCreatorById(creatorId) {

--- a/server/auth/pin-code/index.js
+++ b/server/auth/pin-code/index.js
@@ -23,7 +23,7 @@ let _authorizedEmailsCache = null
 let _authorizedEmailsCacheDate = null
 let _authorizedEmailsPromise = null
 
-async function getAuthorizedEmails() {
+export async function getAuthorizedEmails() {
   if (_authorizedEmailsPromise) {
     return _authorizedEmailsPromise
   }

--- a/server/index.js
+++ b/server/index.js
@@ -168,6 +168,10 @@ server.route('/creator-email/:emailId')
   .get(w(ensureAdmin), w(async (req, res) => {
     const email = await getCreatorById(req.params.emailId)
 
+    if (!email) {
+      throw createError(404, 'Email introuvable')
+    }
+
     res.send(email)
   }))
   .delete(w(ensureAdmin), w(async (req, res) => {

--- a/server/index.js
+++ b/server/index.js
@@ -19,7 +19,7 @@ import errorHandler from './util/error-handler.js'
 import w from './util/w.js'
 
 import {handleAuth, ensureCreator, ensureProjectEditor, ensureAdmin} from './auth/middleware.js'
-import {sendPinCodeEmail, checkPinCodeValidity, isAuthorizedEmail} from './auth/pin-code/index.js'
+import {sendPinCodeEmail, checkPinCodeValidity} from './auth/pin-code/index.js'
 
 import {getProjet, getProjets, deleteProjet, updateProjet, getProjetsGeojson, expandProjet, filterSensitiveFields, createProjet} from './projets.js'
 import {exportEditorKeys, exportLivrablesAsCSV, exportProjetsAsCSV, exportSubventionsAsCSV, exportToursDeTableAsCSV} from '../lib/export/csv.js'
@@ -137,7 +137,7 @@ server.route('/data/editor-keys.csv')
 
 server.route('/ask-code')
   .post(w(async (req, res) => {
-    const authorizedEditorEmail = await isAuthorizedEmail(req.body.email)
+    const authorizedEditorEmail = await getCreatorByEmail(req.body.email)
 
     if (!authorizedEditorEmail) {
       throw createError(401, 'Cette adresse n’est pas autorisée à créer un projet')

--- a/server/index.js
+++ b/server/index.js
@@ -23,6 +23,7 @@ import {sendPinCodeEmail, checkPinCodeValidity, isAuthorizedEmail} from './auth/
 
 import {getProjet, getProjets, deleteProjet, updateProjet, getProjetsGeojson, expandProjet, filterSensitiveFields, createProjet} from './projets.js'
 import {exportEditorKeys, exportLivrablesAsCSV, exportProjetsAsCSV, exportSubventionsAsCSV, exportToursDeTableAsCSV} from '../lib/export/csv.js'
+import {addCreator, deleteCreator, getCreatorById, getCreators, updateCreator, getCreatorByEmail} from './admin/creators-emails.js'
 
 const port = process.env.PORT || 3000
 const dev = process.env.NODE_ENV !== 'production'
@@ -161,6 +162,35 @@ server.route('/me')
     }
 
     res.send({role: req.role})
+  }))
+
+server.route('/creator-email/:emailId')
+  .get(w(ensureAdmin), w(async (req, res) => {
+    const email = await getCreatorById(req.params.emailId)
+
+    res.send(email)
+  }))
+  .delete(w(ensureAdmin), w(async (req, res) => {
+    await deleteCreator(req.params.emailId)
+
+    res.sendStatus(204)
+  }))
+  .put(w(ensureAdmin), w(async (req, res) => {
+    const email = await updateCreator(req.params.emailId, req.body)
+
+    res.send(email)
+  }))
+
+server.route('/creator-emails')
+  .get(w(ensureAdmin), w(async (req, res) => {
+    const emails = await getCreators()
+
+    res.send(emails)
+  }))
+  .post(w(ensureAdmin), w(async (req, res) => {
+    const email = await addCreator(req.body)
+
+    res.send(email)
   }))
 
 server.use(errorHandler)

--- a/server/util/mongo.js
+++ b/server/util/mongo.js
@@ -27,6 +27,7 @@ class Mongo {
     await this.db.collection('creators').createIndex({createdAt: 1}, {expireAfterSeconds: 86400}) // 24 heures
     await this.db.collection('versions').createIndex({_projet: 1})
     await this.db.collection('versions').createIndex({_projet: 1, _created: 1}, {unique: true})
+    await this.db.collection('creators-emails').createIndex({email: 1}, {unique: true})
   }
 
   disconnect(force) {
@@ -45,16 +46,16 @@ class Mongo {
     }
   }
 
-  decorateCreation(projet) {
+  decorateCreation(obj) {
     const now = new Date()
 
-    projet._created = now
-    projet._updated = now
-    projet._id = new ObjectId()
+    obj._created = now
+    obj._updated = now
+    obj._id = new ObjectId()
   }
 
-  decorateUpdate(projet) {
-    projet._updated = new Date()
+  decorateUpdate(obj) {
+    obj._updated = new Date()
   }
 }
 


### PR DESCRIPTION
Actuellement, les adresses mails des personnes autorisés à créer des projets PCRS sont hébergées sur un fichier externe accessible avec un simple lien.

Cette PR ajoute des routes, réservées à l’administration, permettant de gérer la liste des mails des personnes autorisées à créer des projets PCRS.

- Ajout des fonctions permettant de trouver/récupérer/modifier/supprimer une personne autorisée
- Ajout des routes GET/POST/PUT/DELETE
- Ajout d’un script pour migrer les adresses du fichier externe vers la nouvelle collection
- Mise à jour de la documentation
