### PR TITLE
Ajout du lien d'édtion pour les administrateurs

### DIFF
--- a/components/map-sidebar/project-header.js
+++ b/components/map-sidebar/project-header.js
@@ -29,6 +29,8 @@ const Header = ({projectId, codeEditor, projectName, territoires, projets, onPro
 
   const handleDeleteModalOpen = () => setIsDeleteModalOpen(!isDeleteModalOpen)
 
+  const url = `${SHARE_URL}/formulaire-suivi?id=${projectId}&editcode=${codeEditor}`
+
   return (
     <div className='header'>
       <div className='fr-grid-row fr-my-2w'>
@@ -148,6 +150,21 @@ const Header = ({projectId, codeEditor, projectName, territoires, projets, onPro
               <option key={projet.nom} value={projet._id}>{projet.nom}</option>
             ))}
           </select>
+        </div>
+      )}
+      {userRole === 'admin' && (
+        <div className='fr-pt-2w'>
+          <hr />
+          <div>
+            <b>Lien d’édition :</b>
+            <span
+              className='fr-icon-clipboard-line fr-pl-1w'
+              aria-hidden='true'
+              style={{cursor: 'pointer'}}
+              onClick={() => navigator.clipboard.writeText(url)}
+            />
+          </div>
+          <i><a className='fr-text--sm' href={url}>{url}</a></i>
         </div>
       )}
       <style jsx>{`


### PR DESCRIPTION
Cette PR ajoute le lien d'édition du projet, en dessous du nom du projet, afin que les administrateurs aient plus facilement accès à cette information et puissent partager le lien sans avoir à ouvrir le formulaire.

- Affichage du lien dans le composant `project-header`
- Ajout d'une icône cliquable pour faciliter la copie du lien dans le presse-papier

Capture : 

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/78ac6943-068d-46ef-aaff-18cb405b79cf)
