### PR TITLE
Affichage des projets triés par date de création / modification / suppression dans l'espace administrateur

### DIFF
--- a/components/gestion-admin/changes.js
+++ b/components/gestion-admin/changes.js
@@ -37,7 +37,7 @@ const Changes = ({token}) => {
 
   useEffect(() => {
     if (changes?.length > 0 && search) {
-      setFilteredChanges(changes.filter(p => p.nom.includes(search)))
+      setFilteredChanges(changes.filter(p => p.nom.toLowerCase().includes(search.toLowerCase())))
     } else {
       setFilteredChanges(changes)
     }

--- a/components/gestion-admin/changes.js
+++ b/components/gestion-admin/changes.js
@@ -6,8 +6,10 @@ import Loader from '../loader.js'
 
 const Changes = ({token}) => {
   const [changes, setChanges] = useState()
+  const [search, setSearch] = useState()
+  const [filteredChanges, setFilteredChanges] = useState()
 
-  const getChanges = useCallback(async () => {
+  const getAllChanges = useCallback(async () => {
     const response = await fetch('/report', {
       method: 'GET',
       headers: {
@@ -35,44 +37,66 @@ const Changes = ({token}) => {
   }
 
   useEffect(() => {
-    getChanges()
+    if (changes && search) {
+      setFilteredChanges(changes.filter(p => p.nom.includes(search)))
+    } else {
+      setFilteredChanges(changes)
+    }
+  }, [changes, search])
+
+  useEffect(() => {
+    getAllChanges()
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  if (changes?.length === 0) {
-    return <div><i>Aucun changement dans les dernières 24h</i></div>
-  }
-
   return (
     <div>
-      <div className='fr-table fr-table--bordered'>
-        <table>
-          <thead>
-            <tr>
-              <th scope='col' className='fr-p-3w'>Nom du projet</th>
-              <th scope='col' className='fr-p-3w'>Action</th>
-              <th scope='col' className='fr-p-3w'>Depuis</th>
-            </tr>
-          </thead>
-          {changes ? (
-            <tbody>
-              {changes.map(change => {
-                const lastChange = returnLastChange(change)
-                const modificationTime = new Date(change._updated)
+      <div className='fr-col-12 fr-col-md-4'>
+        <label className='fr-label fr-mb-1w'>
+          <b>Rechercher un projet :</b>
+        </label>
+        <div className='fr-search-bar' >
+          <input
+            className='fr-input'
+            placeholder='Chercher un projet'
+            type='search'
+            onChange={e => setSearch(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className='fr-table fr-table--layout-fixed'>
+        {filteredChanges ? (
+          <>
+            <table>
+              <thead>
+                <tr>
+                  <th scope='col' className='fr-p-2w'>Nom du projet</th>
+                  <th scope='col' className='fr-p-2w'>Action</th>
+                  <th scope='col' className='fr-p-2w'>Depuis</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredChanges.map(change => {
+                  const lastChange = returnLastChange(change)
+                  const modificationTime = new Date(change._updated)
 
-                return (
-                  <tr key={change.nom}>
-                    <td className='fr-p-3w'><b>{change?.nom}</b></td>
-                    <td className='fr-p-3w'>{lastChange}</td>
-                    <td className='fr-p-3w'><i>{`(Il y a ${formatDistanceToNow(modificationTime, {locale: fr})})`}</i></td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          ) : (
-            <Loader />
-          )}
-        </table>
+                  return (
+                    <tr key={change.nom}>
+                      <td className='fr-p-2w'><b>{change?.nom}</b></td>
+                      <td className='fr-p-2w'>{lastChange}</td>
+                      <td className='fr-p-2w'><i>{`(Il y a ${formatDistanceToNow(modificationTime, {locale: fr})})`}</i></td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+            {filteredChanges.length === 0 && (
+              <div className='fr-p-2w'><i>Aucun résultat...</i></div>
+            )}
+          </>
+        ) : (
+          <Loader />
+        )}
       </div>
     </div>
   )

--- a/components/gestion-admin/changes.js
+++ b/components/gestion-admin/changes.js
@@ -1,0 +1,85 @@
+import {useEffect, useCallback, useState} from 'react'
+import PropTypes from 'prop-types'
+import formatDistanceToNow from 'date-fns/formatDistanceToNow'
+import {fr} from 'date-fns/locale'
+import Loader from '../loader.js'
+
+const Changes = ({token}) => {
+  const [changes, setChanges] = useState()
+
+  const getChanges = useCallback(async () => {
+    const response = await fetch('/report', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Token ${token}`
+      }
+    })
+
+    const projetsChanges = await response.json()
+
+    setChanges(projetsChanges)
+  }, [token])
+
+  function returnLastChange(change) {
+    if (change._deleted) {
+      return 'Suppression'
+    }
+
+    if (change._updated !== change._created) {
+      return 'Mise à jour'
+    }
+
+    return 'Création'
+  }
+
+  useEffect(() => {
+    getChanges()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  if (changes?.length === 0) {
+    return <div><i>Aucun changement dans les dernières 24h</i></div>
+  }
+
+  return (
+    <div>
+      <div className='fr-table fr-table--bordered'>
+        <table>
+          <thead>
+            <tr>
+              <th scope='col' className='fr-p-3w'>Nom du projet</th>
+              <th scope='col' className='fr-p-3w'>Action</th>
+              <th scope='col' className='fr-p-3w'>Depuis</th>
+            </tr>
+          </thead>
+          {changes ? (
+            <tbody>
+              {changes.map(change => {
+                const lastChange = returnLastChange(change)
+                const modificationTime = new Date(change._updated)
+
+                return (
+                  <tr key={change.nom}>
+                    <td className='fr-p-3w'><b>{change?.nom}</b></td>
+                    <td className='fr-p-3w'>{lastChange}</td>
+                    <td className='fr-p-3w'><i>{`(Il y a ${formatDistanceToNow(modificationTime, {locale: fr})})`}</i></td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          ) : (
+            <Loader />
+          )}
+        </table>
+      </div>
+    </div>
+  )
+}
+
+Changes.propTypes = {
+  token: PropTypes.string.isRequired
+}
+
+export default Changes

--- a/components/gestion-admin/changes.js
+++ b/components/gestion-admin/changes.js
@@ -2,6 +2,7 @@ import {useEffect, useCallback, useState} from 'react'
 import PropTypes from 'prop-types'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import {fr} from 'date-fns/locale'
+
 import Loader from '../loader.js'
 
 const Changes = ({token}) => {

--- a/components/gestion-admin/changes.js
+++ b/components/gestion-admin/changes.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import {fr} from 'date-fns/locale'
 
-import Loader from '../loader.js'
+import Loader from '@/components/loader.js'
 import {getAllChanges} from '@/lib/suivi-pcrs.js'
 import colors from '@/styles/colors.js'
 

--- a/components/gestion-admin/changes.js
+++ b/components/gestion-admin/changes.js
@@ -4,25 +4,23 @@ import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import {fr} from 'date-fns/locale'
 
 import Loader from '../loader.js'
+import {getAllChanges} from '@/lib/suivi-pcrs.js'
+import colors from '@/styles/colors.js'
 
 const Changes = ({token}) => {
   const [changes, setChanges] = useState()
   const [search, setSearch] = useState()
+  const [error, setError] = useState()
   const [filteredChanges, setFilteredChanges] = useState()
 
-  const getAllChanges = useCallback(async () => {
-    const response = await fetch('/report', {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Token ${token}`
-      }
-    })
+  const getChanges = useCallback(async () => {
+    const response = await getAllChanges(token)
 
-    const projetsChanges = await response.json()
-
-    setChanges(projetsChanges)
+    if (response.message) {
+      setError(response.message)
+    } else {
+      setChanges(response)
+    }
   }, [token])
 
   function returnLastChange(change) {
@@ -38,7 +36,7 @@ const Changes = ({token}) => {
   }
 
   useEffect(() => {
-    if (changes && search) {
+    if (changes?.length > 0 && search) {
       setFilteredChanges(changes.filter(p => p.nom.includes(search)))
     } else {
       setFilteredChanges(changes)
@@ -46,7 +44,7 @@ const Changes = ({token}) => {
   }, [changes, search])
 
   useEffect(() => {
-    getAllChanges()
+    getChanges()
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -95,9 +93,13 @@ const Changes = ({token}) => {
               <div className='fr-p-2w'><i>Aucun résultat...</i></div>
             )}
           </>
+        ) : (error ? (
+          <div style={{color: colors.error425}}>
+            <i>Une erreur est survenue : {error}</i>
+          </div>
         ) : (
           <Loader />
-        )}
+        ))}
       </div>
     </div>
   )

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -197,3 +197,16 @@ export async function resetEditCode(projetId, token) {
   }
 }
 
+export async function getAllChanges(token) {
+  const response = await fetch('/report', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Token ${token}`
+    }
+  })
+
+  return response.json()
+}
+

--- a/pages/gestion-suivi.js
+++ b/pages/gestion-suivi.js
@@ -8,6 +8,7 @@ import Page from '@/layouts/main.js'
 
 import AdminAuthentificationModal from '@/components/suivi-form/authentification/admin-authentification-modal.js'
 import Porteurs from '@/components/gestion-admin/porteurs.js'
+import Changes from '@/components/gestion-admin/changes.js'
 
 const Admin = () => {
   const router = useRouter()
@@ -59,6 +60,17 @@ const Admin = () => {
                 Administrateurs
               </button>
             </li>
+            <li role='presentation'>
+              <button
+                type='button'
+                className='fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left'
+                role='tab'
+                aria-selected={activeTab === 'changes' ? 'true' : 'false'}
+                onClick={() => setActiveTab('changes')}
+              >
+                Projets édités récemment
+              </button>
+            </li>
           </ul>
           {activeTab === 'porteurs' && (
             <div className='fr-tabs__panel fr-tabs__panel--selected' role='tabpanel'>
@@ -69,6 +81,12 @@ const Admin = () => {
           {activeTab === 'admin' && (
             <div className='fr-tabs__panel fr-tabs__panel--selected' role='tabpanel'>
               <i>Bientôt disponible</i>
+            </div>
+          )}
+
+          {activeTab === 'changes' && (
+            <div className='fr-tabs__panel fr-tabs__panel--selected' role='tabpanel'>
+              <Changes token={token} />
             </div>
           )}
         </div>

--- a/pages/gestion-suivi.js
+++ b/pages/gestion-suivi.js
@@ -33,7 +33,7 @@ const Admin = () => {
         <h2 className='fr-mt-5w fr-mb-0'>Gestion des suivis</h2>
       </div>
 
-      <div className='fr-px-4w'>
+      <div className='fr-px-md-1w'>
         <h3 className='fr-h6 fr-mb-6w'><span className='fr-icon-file-text-line' aria-hidden='true' /> Liste des administrateurs et porteurs de projets</h3>
 
         <div className='fr-tabs'>


### PR DESCRIPTION
Cette PR ajoute l'affichage de la liste des projets triés par date de création / modification / suppression dans l'espace d'administration afin que les administrateurs puissent visualiser les modifications récentes effectuées sur le suivi des projets PCRS.

- Ajout d'un onglet pour afficher la liste
- Affichage de la liste dans un tableau
- Ajout d'un filtre pour chercher un projet
- Réduction des marges en version mobile

### Capture

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/57dcd49a-f102-4f7c-bfdf-dfcacbe8405c)
