### PR TITLE
Ajout de fonctionnalités sur la carte de suivi

### DIFF
--- a/components/map/layers/departement-fill-nature.json
+++ b/components/map/layers/departement-fill-nature.json
@@ -1,0 +1,25 @@
+{
+  "id": "departements-fills-nature",
+  "type": "fill",
+  "source": "projetsData",
+  "layout": {
+    "visibility": "none"
+  },
+  "paint": {
+    "fill-color": [
+      "match",
+      ["get", "nature"],
+      "raster", "#fc916f",
+      "vecteur", "#86b6d8",
+      "mixte", "#cf7bb9",
+      "white"
+    ],
+   "fill-opacity": [
+      "case",
+      ["boolean", ["feature-state", "hover"], false],
+      1,
+      0.5
+    ],
+    "fill-outline-color": "grey"
+  }
+}

--- a/components/map/legend.js
+++ b/components/map/legend.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import {PCRS_DATA_COLORS} from '@/styles/pcrs-data-colors.js'
 import Badge from '@/components/badge.js'
 
-const Legend = ({isMobile}) => {
-  const {status} = PCRS_DATA_COLORS
+const Legend = ({isMobile, legend}) => {
+  const {status, natures} = PCRS_DATA_COLORS
   const [isOpen, setIsOpen] = useState(!isMobile)
 
   return (
@@ -22,11 +22,22 @@ const Legend = ({isMobile}) => {
       {isOpen ? (
         <>
           <span><u>Légende :</u></span>
-          <Badge className='fr-pb-1v fr-pt-1v' size='small' background={status.investigation}>Investigation</Badge>
-          <Badge className='fr-pb-1v' size='small' background={status.production}>Production</Badge>
-          <Badge className='fr-pb-1v' size='small' background={status.produit}>Produit</Badge>
-          <Badge className='fr-pb-1v' size='small' background={status.livre} textColor='snow'>Livré</Badge>
-          <Badge className='fr-pb-2v' size='small' background={status.obsolete} textColor='snow'>Obsolète</Badge>
+          {(legend === 'statut' || !legend) && (
+            <>
+              <Badge className='fr-pb-1v fr-pt-1v' size='small' background={status.investigation}>Investigation</Badge>
+              <Badge className='fr-pb-1v' size='small' background={status.production}>Production</Badge>
+              <Badge className='fr-pb-1v' size='small' background={status.produit}>Produit</Badge>
+              <Badge className='fr-pb-1v' size='small' background={status.livre} textColor='snow'>Livré</Badge>
+              <Badge className='fr-pb-2v' size='small' background={status.obsolete} textColor='snow'>Obsolète</Badge>
+            </>
+          )}
+          {legend === 'nature' && (
+            <>
+              <Badge className='fr-pb-1v fr-pt-1v' size='small' background={natures.vecteur}>Vecteur</Badge>
+              <Badge className='fr-pb-1v' size='small' background={natures.raster}>Raster</Badge>
+              <Badge className='fr-pb-2v' size='small' background={natures.mixte}>Mixte</Badge>
+            </>
+          )}
           <hr className='fr-p-1v' />
           <span
             className='fr-icon--sm fr-icon-close-circle-line'

--- a/components/map/legend.js
+++ b/components/map/legend.js
@@ -68,11 +68,13 @@ const Legend = ({isMobile, legend}) => {
 }
 
 Legend.defaultProps = {
-  isMobile: true
+  isMobile: true,
+  legend: 'departements-fills'
 }
 
 Legend.propTypes = {
-  isMobile: PropTypes.bool
+  isMobile: PropTypes.bool,
+  legend: PropTypes.string
 }
 
 export default Legend

--- a/components/map/legend.js
+++ b/components/map/legend.js
@@ -22,7 +22,7 @@ const Legend = ({isMobile, legend}) => {
       {isOpen ? (
         <>
           <span><u>Légende :</u></span>
-          {(legend === 'statut' || !legend) && (
+          {(legend === 'departements-fills' || !legend) && (
             <>
               <Badge className='fr-pb-1v fr-pt-1v' size='small' background={status.investigation}>Investigation</Badge>
               <Badge className='fr-pb-1v' size='small' background={status.production}>Production</Badge>
@@ -31,7 +31,7 @@ const Legend = ({isMobile, legend}) => {
               <Badge className='fr-pb-2v' size='small' background={status.obsolete} textColor='snow'>Obsolète</Badge>
             </>
           )}
-          {legend === 'nature' && (
+          {legend === 'departements-fills-nature' && (
             <>
               <Badge className='fr-pb-1v fr-pt-1v' size='small' background={natures.vecteur}>Vecteur</Badge>
               <Badge className='fr-pb-1v' size='small' background={natures.raster}>Raster</Badge>

--- a/components/map/map-tool-box.js
+++ b/components/map/map-tool-box.js
@@ -1,0 +1,56 @@
+import {useState} from 'react'
+import PropTypes from 'prop-types'
+
+const MapToolBox = ({children}) => {
+  const [isOpen, setIsOpen] = useState()
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        right: '8px',
+        top: '110px',
+        backgroundColor: 'rgba(255, 255, 255, .9)',
+        padding: '3px',
+        borderRadius: '5px',
+        width: isOpen ? '300px' : '',
+        border: '2px solid #dfdbd8'
+      }}
+    >
+      {isOpen ? (
+        <div
+          className='fr-p-1w'
+        >
+          <span
+            className='fr-icon-close-circle-line'
+            aria-hidden='true'
+            style={{
+              position: 'absolute',
+              verticalAlign: 'middle',
+              cursor: 'pointer',
+              right: '3px',
+              top: '3px'
+            }}
+            onClick={() => setIsOpen(false)}
+          />
+          <span className='fr-pb-1w'><u>Affichage carte</u> :</span>
+          <hr />
+          {children}
+        </div>
+      ) : (
+        <span
+          className='fr-icon-add-circle-line'
+          style={{
+            cursor: 'pointer'
+          }}
+          onClick={() => setIsOpen(true)}
+        />
+      )}
+    </div>
+  )
+}
+
+MapToolBox.propTypes = {
+  children: PropTypes.node
+}
+
+export default MapToolBox

--- a/components/map/map-tool-box.js
+++ b/components/map/map-tool-box.js
@@ -27,8 +27,8 @@ const MapToolBox = ({children}) => {
               position: 'absolute',
               verticalAlign: 'middle',
               cursor: 'pointer',
-              right: '3px',
-              top: '3px'
+              right: '5px',
+              top: '5px'
             }}
             onClick={() => setIsOpen(false)}
           />
@@ -38,7 +38,7 @@ const MapToolBox = ({children}) => {
         </div>
       ) : (
         <span
-          className='fr-icon-add-circle-line'
+          className='fr-icon-filter-line'
           style={{
             cursor: 'pointer'
           }}

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -158,14 +158,14 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
   useEffect(() => {
     if (mapRef?.current.isStyleLoaded()) {
       mapRef.current.setFilter(
-        'departements-fills',
+        layout,
         ['in',
           porteur.toLowerCase(),
           ['string',
             ['downcase', ['get', 'aplc']]]]
       )
     }
-  }, [porteur])
+  }, [porteur, layout])
 
   useEffect(() => {
     if (mapRef?.current.isStyleLoaded() && projetId) {

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -89,6 +89,16 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
     setHoveredCode(null)
   }, [hoveredCode, popupRoot])
 
+  const mapFilter = useCallback(() => {
+    mapRef.current.setFilter(
+      layout,
+      ['in',
+        porteur.toLowerCase(),
+        ['string',
+          ['downcase', ['get', 'aplc']]]]
+    )
+  }, [layout, porteur])
+
   useEffect(() => {
     const node = mapNode.current
     const maplibreMap = new maplibreGl.Map({
@@ -158,20 +168,16 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
         mapRef.current.setLayoutProperty('departements-fills', 'visibility', 'visible')
         mapRef.current.setLayoutProperty('departements-fills-nature', 'visibility', 'none')
       }
+
+      mapFilter(porteur)
     }
-  }, [layout])
+  }, [layout, porteur, mapFilter])
 
   useEffect(() => {
     if (mapRef?.current.isStyleLoaded()) {
-      mapRef.current.setFilter(
-        layout,
-        ['in',
-          porteur.toLowerCase(),
-          ['string',
-            ['downcase', ['get', 'aplc']]]]
-      )
+      mapFilter(porteur)
     }
-  }, [porteur, layout])
+  }, [porteur, layout, mapFilter])
 
   useEffect(() => {
     if (mapRef?.current.isStyleLoaded() && projetId) {

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -64,6 +64,9 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
     maplibreMap.on('click', 'departements-fills', e => {
       handleClick(e)
     })
+    maplibreMap.on('click', 'departements-fills-nature', e => {
+      handleClick(e)
+    })
 
     if (!isMobile) {
       maplibreMap.on('mousemove', 'departements-fills', e => {

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -41,18 +41,6 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
   const popupRoot = createRoot(popupNode)
 
   useEffect(() => {
-    if (mapRef?.current?.isStyleLoaded()) {
-      if (layout === 'nature') {
-        mapRef.current.setLayoutProperty('departements-fills-nature', 'visibility', 'visible')
-      }
-
-      if (layout === 'statut') {
-        mapRef.current.setLayoutProperty('departements-fills-nature', 'visibility', 'none')
-      }
-    }
-  }, [layout])
-
-  useEffect(() => {
     const node = mapNode.current
     let hoveredCode = null
     let projet = null
@@ -109,24 +97,6 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
         }
       })
     }
-
-    maplibreMap.on('click', 'departements-fills', e => {
-      if (e.features.length > 0) {
-        if (selectedCode.current !== undefined) {
-          maplibreMap.setFeatureState(
-            {source: 'projetsData', id: selectedCode.current},
-            {hover: false}
-          )
-        }
-
-        selectedCode.current = e.features[0].id
-
-        maplibreMap.setFeatureState(
-          {source: 'projetsData', id: selectedCode.current},
-          {hover: true}
-        )
-      }
-    })
 
     maplibreMap.on('mouseleave', 'departements-fills', () => {
       if (hoveredCode !== null) {

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -16,6 +16,7 @@ import AuthentificationContext from '@/contexts/authentification-token.js'
 import Popup from '@/components/map/popup.js'
 import Loader from '@/components/loader.js'
 import Legend from '@/components/map/legend.js'
+import MapToolBox from '@/components/map/map-tool-box.js'
 import AuthentificationModal from '@/components/suivi-form/authentification/authentification-modal.js'
 
 const Map = ({handleClick, isMobile, geometry, projetId}) => {
@@ -192,6 +193,53 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
         legend={layout}
       />
 
+      <MapToolBox>
+        <div className='fr-grid-row fr-grid-row--gutters fr-p-2w'>
+          <div
+            style={{
+              backgroundColor: 'white'
+            }}
+          >
+            <label className='fr-label'>Filtrer par APLC :</label>
+            <div className='fr-grid-row'>
+              <input
+                type='text'
+                className='fr-input fr-col-10'
+                placeholder='Nom d’un APLC'
+                value={porteur || ''}
+                onChange={e => setPorteur(e.target.value)}
+              />
+              <button
+                type='button'
+                className='fr-btn fr-btn--sm fr-icon-close-circle-line fr-col-2 fr-m-auto'
+                onClick={() => setPorteur('')}
+              />
+            </div>
+          </div>
+          <div className='fr-p-1w fr-pt-3w'>
+            <div>Colorisation de la carte par :</div>
+            <div>
+              <button
+                type='button'
+                className='fr-btn fr-btn--sm fr-m-1w'
+                disabled={layout === 'departements-fills-nature'}
+                onClick={() => setLayout('departements-fills-nature')}
+              >
+                nature
+              </button>
+              <button
+                type='button'
+                className='fr-btn fr-btn--sm fr-m-1w'
+                disabled={layout === 'departements-fills'}
+                onClick={() => setLayout('departements-fills')}
+              >
+                statut
+              </button>
+            </div>
+          </div>
+        </div>
+      </MapToolBox>
+
       <button
         type='button'
         className='fr-btn fr-btn--icon-left fr-icon-add-circle-fill'
@@ -204,29 +252,6 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
       >
         Ajouter un projet
       </button>
-      <button
-        type='button'
-        className='fr-btn fr-btn--sm'
-        style={{
-          position: 'fixed',
-          right: 10,
-          bottom: '100px'
-        }}
-        onClick={() => setLayout(layout === 'departements-fills-nature' ? 'departements-fills' : 'departements-fills-nature')}
-      >
-        Afficher par {layout === 'departements-fills' ? 'nature' : 'statut'}
-      </button>
-      <input
-        type='text'
-        className='fr-input'
-        style={{
-          position: 'fixed',
-          right: 10,
-          bottom: '130px',
-          width: '150px'
-        }}
-        onChange={e => setPorteur(e.target.value)}
-      />
 
       {isAuthentificationModalOpen && userRole !== 'admin' && <AuthentificationModal handleModalClose={handleModal} />}
     </div>

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -21,7 +21,7 @@ import AuthentificationModal from '@/components/suivi-form/authentification/auth
 const Map = ({handleClick, isMobile, geometry, projetId}) => {
   const {userRole, token} = useContext(AuthentificationContext)
   const router = useRouter()
-  const [layout, setLayout] = useState()
+  const [layout, setLayout] = useState('departements-fills')
 
   const [isAuthentificationModalOpen, setIsAuthentificationModalOpen] = useState(false)
 
@@ -167,6 +167,18 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    if (mapRef?.current?.isStyleLoaded()) {
+      if (layout === 'departements-fills-nature') {
+        mapRef.current.setLayoutProperty('departements-fills-nature', 'visibility', 'visible')
+        mapRef.current.setLayoutProperty('departements-fills', 'visibility', 'none')
+      }
+
+      if (layout === 'departements-fills') {
+        mapRef.current.setLayoutProperty('departements-fills', 'visibility', 'visible')
+        mapRef.current.setLayoutProperty('departements-fills-nature', 'visibility', 'none')
+      }
+    }
+  }, [layout])
     if (mapRef?.current.isStyleLoaded() && projetId) {
       if (selectedCode?.current && selectedCode?.current !== projetId) {
         mapRef.current.setFeatureState(
@@ -212,9 +224,9 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
           right: 10,
           bottom: '100px'
         }}
-        onClick={() => setLayout(layout === 'nature' ? 'statut' : 'nature')}
+        onClick={() => setLayout(layout === 'departements-fills-nature' ? 'departements-fills' : 'departements-fills-nature')}
       >
-        Afficher par {layout === 'nature' ? 'statut' : 'nature'}
+        Afficher par {layout === 'departements-fills' ? 'nature' : 'statut'}
       </button>
 
       {isAuthentificationModalOpen && userRole !== 'admin' && <AuthentificationModal handleModalClose={handleModal} />}

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -22,6 +22,7 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
   const {userRole, token} = useContext(AuthentificationContext)
   const router = useRouter()
   const [layout, setLayout] = useState('departements-fills')
+  const [porteur, setPorteur] = useState()
 
   const [isAuthentificationModalOpen, setIsAuthentificationModalOpen] = useState(false)
 
@@ -152,6 +153,20 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
       }
     }
   }, [layout])
+
+  useEffect(() => {
+    if (mapRef?.current.isStyleLoaded()) {
+      mapRef.current.setFilter(
+        'departements-fills',
+        ['in',
+          porteur.toLowerCase(),
+          ['string',
+            ['downcase', ['get', 'aplc']]]]
+      )
+    }
+  }, [porteur])
+
+  useEffect(() => {
     if (mapRef?.current.isStyleLoaded() && projetId) {
       if (selectedCode?.current && selectedCode?.current !== projetId) {
         mapRef.current.setFeatureState(
@@ -201,6 +216,17 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
       >
         Afficher par {layout === 'departements-fills' ? 'nature' : 'statut'}
       </button>
+      <input
+        type='text'
+        className='fr-input'
+        style={{
+          position: 'fixed',
+          right: 10,
+          bottom: '130px',
+          width: '150px'
+        }}
+        onChange={e => setPorteur(e.target.value)}
+      />
 
       {isAuthentificationModalOpen && userRole !== 'admin' && <AuthentificationModal handleModalClose={handleModal} />}
     </div>

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -7,6 +7,7 @@ import maplibreGl from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
 import departementFillLayer from './layers/departement-fill.json'
+import departementFillNature from './layers/departement-fill-nature.json'
 import departementLayer from './layers/departement-layer.json'
 import vector from './styles/vector.json'
 
@@ -20,6 +21,7 @@ import AuthentificationModal from '@/components/suivi-form/authentification/auth
 const Map = ({handleClick, isMobile, geometry, projetId}) => {
   const {userRole, token} = useContext(AuthentificationContext)
   const router = useRouter()
+  const [layout, setLayout] = useState()
 
   const [isAuthentificationModalOpen, setIsAuthentificationModalOpen] = useState(false)
 
@@ -37,6 +39,18 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
   }))
   const popupNode = document.createElement('div')
   const popupRoot = createRoot(popupNode)
+
+  useEffect(() => {
+    if (mapRef?.current?.isStyleLoaded()) {
+      if (layout === 'nature') {
+        mapRef.current.setLayoutProperty('departements-fills-nature', 'visibility', 'visible')
+      }
+
+      if (layout === 'statut') {
+        mapRef.current.setLayoutProperty('departements-fills-nature', 'visibility', 'none')
+      }
+    }
+  }, [layout])
 
   useEffect(() => {
     const node = mapNode.current
@@ -142,6 +156,7 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
       }
 
       maplibreMap.addLayer(departementFillLayer)
+      maplibreMap.addLayer(departementFillNature)
       maplibreMap.addLayer(departementLayer)
     })
 
@@ -172,7 +187,10 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
   return (
     <div style={{position: 'relative', height: '100%', width: '100%'}}>
       <div ref={mapNode} style={{width: '100%', height: '100%'}} />
-      <Legend isMobile={isMobile === true} />
+      <Legend
+        isMobile={isMobile === true}
+        legend={layout}
+      />
 
       <button
         type='button'
@@ -185,6 +203,18 @@ const Map = ({handleClick, isMobile, geometry, projetId}) => {
         onClick={() => token ? router.push('/formulaire-suivi') : handleModal()}
       >
         Ajouter un projet
+      </button>
+      <button
+        type='button'
+        className='fr-btn fr-btn--sm'
+        style={{
+          position: 'fixed',
+          right: 10,
+          bottom: '100px'
+        }}
+        onClick={() => setLayout(layout === 'nature' ? 'statut' : 'nature')}
+      >
+        Afficher par {layout === 'nature' ? 'statut' : 'nature'}
       </button>
 
       {isAuthentificationModalOpen && userRole !== 'admin' && <AuthentificationModal handleModalClose={handleModal} />}


### PR DESCRIPTION
Cette PR ajoute un layer ainsi qu'un filtre permettant d'ajuster la visualisation des données de suivi de la carte.

- Ajout d'un filtre permettant d'afficher uniquement les projets concernés par un porteur de projet donné.
- Ajout d'un layer permettant d'afficher les projets colorisés par "nature" (vecteur, raster ou mixte).
- Ajout d'une "boite à outils" pour afficher les nouvelles options sans masquer la carte.

Technique : 
- Création de fonction afin de simplifier les événements "onClick" et "onHover" de la carte.
- Suppression d'une partie de code qui n'était plus utilisée.
- Mise à jour de la légende.

### Captures : 

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/6d45a2c0-a570-4b2c-8b38-77618437dbc3)

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/cd91c6ac-3583-4849-b174-8b5b62a6ddb3)

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/41a08126-a20d-4d08-96fe-f7a16810c8c8)
