### PR TITLE
Amélioration de la compréhension de la récupération de code d'édition

### DIFF
--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -22,7 +22,7 @@ import DeleteModal from '@/components/suivi-form/delete-modal.js'
 import Button from '@/components/button.js'
 import colors from '@/styles/colors.js'
 
-const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subventions, etapes, _id, token, userRole, editionCode, isTokenRecovering}) => {
+const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subventions, etapes, _id, token, userRole, projectEditCode, isTokenRecovering}) => {
   const router = useRouter()
 
   const [isShareModalOpen, setIsShareModalOpen] = useState(false)
@@ -34,7 +34,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const [editedProjectId, setEditedProjectId] = useState(null)
-  const [editCode, setEditCode] = useState(null)
+  const [editCode, setEditCode] = useState(projectEditCode)
 
   const [suiviNom, setSuiviNom] = useInput({initialValue: nom})
   const [suiviNature, setSuiviNature] = useInput({initialValue: nature})
@@ -97,7 +97,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
           subventions: projetSubventions
         }
 
-        const authorisationCode = editionCode || token
+        const authorisationCode = editCode || token
         const sendSuivi = _id ? await editProject(suivi, _id, authorisationCode) : await postSuivi(suivi, token)
 
         setEditedProjectId(sendSuivi._id)
@@ -156,7 +156,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
         <h2 className='fr-mt-5w fr-mb-0'>Formulaire de suivi PCRS</h2>
       </div>
       <div className='fr-p-5w'>
-        {(!token && !isTokenRecovering && !editionCode) && <AuthentificationModal handleModalClose={handleAuthentificationModal} />}
+        {(!token && !isTokenRecovering && !editCode) && <AuthentificationModal handleModalClose={handleAuthentificationModal} />}
 
         <div className='fr-grid-row fr-col-12'>
           <div className='fr-grid-row fr-grid-row--left fr-col-12 fr-col-md-10'>
@@ -282,7 +282,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
               <DeleteModal
                 nom={nom}
                 id={_id}
-                token={editionCode}
+                token={editCode}
                 handleDeleteModalOpen={handleDeleteModalOpen}
               />
             )}
@@ -353,7 +353,7 @@ SuiviForm.propTypes = {
   subventions: PropTypes.array,
   _id: PropTypes.string,
   token: PropTypes.string,
-  editionCode: PropTypes.string,
+  projectEditCode: PropTypes.string,
   isTokenRecovering: PropTypes.bool.isRequired
 }
 
@@ -368,7 +368,7 @@ SuiviForm.defaultProps = {
   etapes: [{statut: 'investigation', date_debut: ''}], // eslint-disable-line camelcase
   subventions: [],
   _id: null,
-  editionCode: null,
+  projectEditCode: null,
   token: null
 }
 

--- a/pages/formulaire-suivi.js
+++ b/pages/formulaire-suivi.js
@@ -12,7 +12,7 @@ import Page from '@/layouts/main.js'
 import Button from '@/components/button.js'
 import SuiviForm from '@/components/suivi-form/index.js'
 
-const FormulaireSuivi = ({project, isNotFound, isForbidden, editionCode}) => {
+const FormulaireSuivi = ({project, isNotFound, isForbidden, editCode}) => {
   const {token, userRole, isTokenRecovering} = useContext(AuthentificationContext)
 
   if (isNotFound || isForbidden) {
@@ -53,7 +53,7 @@ const FormulaireSuivi = ({project, isNotFound, isForbidden, editionCode}) => {
       <SuiviForm
         userRole={userRole}
         token={token}
-        editionCode={editionCode}
+        projectEditCode={editCode}
         isTokenRecovering={isTokenRecovering}
         {...project}
       />
@@ -74,7 +74,7 @@ FormulaireSuivi.getInitialProps = async ({query}) => {
     if (query.editcode) {
       return {
         project,
-        editionCode: query.editcode
+        editCode: query.editcode
       }
     }
 
@@ -89,13 +89,13 @@ FormulaireSuivi.getInitialProps = async ({query}) => {
 
 FormulaireSuivi.propTypes = {
   project: PropTypes.object,
-  editionCode: PropTypes.string,
+  editCode: PropTypes.string,
   isNotFound: PropTypes.bool,
   isForbidden: PropTypes.bool
 }
 
 FormulaireSuivi.defaultProps = {
-  editionCode: null,
+  editCode: null,
   isNotFound: false,
   isForbidden: false
 }


### PR DESCRIPTION
La gestion de la récupération du code d'édition d'un projet était difficilement compréhensible.

Sur le composant du formulaire de suivi, la state `editCode` prend comme valeur initiale le code d'édition d'un projet si le formulaire contient les données à éditer (formulaire en "mode édition").
Dans le cas d'un formulaire vierge, `editCode` sera `null` par défaut et récupéré à la création du projet.