### PR TITLE
Correction de l'affichage de la modale de connexion

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -6,7 +6,6 @@ import AdminAuthentificationModal from '@/components/suivi-form/authentification
 const Footer = () => {
   const [isAuthentificationModalOpen, setIsAuthentificationModalOpen] = useState(false)
 
-  const handleModal = () => setIsAuthentificationModalOpen(!isAuthentificationModalOpen)
   return (
     <>
       <footer className='fr-footer' role='contentinfo' id='footer'>
@@ -104,7 +103,7 @@ const Footer = () => {
         </div>
       </footer>
 
-      {isAuthentificationModalOpen && <AdminAuthentificationModal handleModalClose={handleModal} />}
+      {isAuthentificationModalOpen && <AdminAuthentificationModal handleIsModalOpen={setIsAuthentificationModalOpen} />}
     </>
   )
 }

--- a/components/suivi-form/authentification/admin-authentification-modal.js
+++ b/components/suivi-form/authentification/admin-authentification-modal.js
@@ -1,6 +1,5 @@
 import {useState, useContext} from 'react'
 import PropTypes from 'prop-types'
-import {useRouter} from 'next/router'
 
 import {authentificationRole} from '@/lib/authentification.js'
 
@@ -10,8 +9,7 @@ import TextInput from '@/components/text-input.js'
 import Modal from '@/components/modal.js'
 import Button from '@/components/button.js'
 
-const AdminAuthentificationModal = ({handleModalOpen}) => {
-  const router = useRouter()
+const AdminAuthentificationModal = ({handleIsModalOpen, onModalClose}) => {
   const {storeToken} = useContext(AuthentificationContext)
 
   const [tokenInput, setTokenInput] = useState('')
@@ -27,10 +25,10 @@ const AdminAuthentificationModal = ({handleModalOpen}) => {
         const getUserRole = await authentificationRole(tokenInput)
         if (getUserRole.role === 'admin') {
           storeToken(tokenInput)
-          setValidationMessage('Administrateur authentifié avec succès ! Vous allez être redirigé...')
+          setValidationMessage('Administrateur authentifié avec succès !')
 
           setTimeout(() => {
-            handleModalOpen(false)
+            handleIsModalOpen(false)
           }, 3000)
         } else {
           setErrorMessage('Le jeton entré ne correspond pas à un jeton administrateur existant')
@@ -44,7 +42,7 @@ const AdminAuthentificationModal = ({handleModalOpen}) => {
   }
 
   return (
-    <Modal title='S’authentifier' onClose={() => validationMessage ? handleModalOpen(false) : router.push('/suivi-pcrs')}>
+    <Modal title='S’authentifier' onClose={() => onModalClose() || handleIsModalOpen(false)}>
       <div>
         <p>Afin de vérifier vos droit en tant qu’administrateur, nous devons procéder à la vérification de votre jeton d’authentification.<br /><br />
           Une fois authentifié, vous serez en mesure d’accéder au formulaire de suivi du PCRS
@@ -87,7 +85,12 @@ const AdminAuthentificationModal = ({handleModalOpen}) => {
 }
 
 AdminAuthentificationModal.propTypes = {
-  handleModalOpen: PropTypes.func.isRequired
+  handleIsModalOpen: PropTypes.func.isRequired,
+  onModalClose: PropTypes.func
+}
+
+AdminAuthentificationModal.defaultProps = {
+  onModalClose() {}
 }
 
 export default AdminAuthentificationModal

--- a/components/suivi-form/authentification/admin-authentification-modal.js
+++ b/components/suivi-form/authentification/admin-authentification-modal.js
@@ -1,5 +1,6 @@
 import {useState, useContext} from 'react'
 import PropTypes from 'prop-types'
+import {useRouter} from 'next/router'
 
 import {authentificationRole} from '@/lib/authentification.js'
 
@@ -9,7 +10,8 @@ import TextInput from '@/components/text-input.js'
 import Modal from '@/components/modal.js'
 import Button from '@/components/button.js'
 
-const AdminAuthentificationModal = ({handleModalClose}) => {
+const AdminAuthentificationModal = ({handleModalOpen}) => {
+  const router = useRouter()
   const {storeToken} = useContext(AuthentificationContext)
 
   const [tokenInput, setTokenInput] = useState('')
@@ -28,7 +30,7 @@ const AdminAuthentificationModal = ({handleModalClose}) => {
           setValidationMessage('Administrateur authentifié avec succès ! Vous allez être redirigé...')
 
           setTimeout(() => {
-            handleModalClose()
+            handleModalOpen(false)
           }, 3000)
         } else {
           setErrorMessage('Le jeton entré ne correspond pas à un jeton administrateur existant')
@@ -42,7 +44,7 @@ const AdminAuthentificationModal = ({handleModalClose}) => {
   }
 
   return (
-    <Modal title='S’authentifier' onClose={handleModalClose}>
+    <Modal title='S’authentifier' onClose={() => validationMessage ? handleModalOpen(false) : router.push('/suivi-pcrs')}>
       <div>
         <p>Afin de vérifier vos droit en tant qu’administrateur, nous devons procéder à la vérification de votre jeton d’authentification.<br /><br />
           Une fois authentifié, vous serez en mesure d’accéder au formulaire de suivi du PCRS
@@ -85,7 +87,7 @@ const AdminAuthentificationModal = ({handleModalClose}) => {
 }
 
 AdminAuthentificationModal.propTypes = {
-  handleModalClose: PropTypes.func.isRequired
+  handleModalOpen: PropTypes.func.isRequired
 }
 
 export default AdminAuthentificationModal

--- a/contexts/authentification-token.js
+++ b/contexts/authentification-token.js
@@ -9,7 +9,7 @@ const TOKEN_KEY = 'Token'
 export const AuthentificationContextProvider = props => {
   const [token, setToken] = useState(null)
   const [userRole, setUserRole] = useState(null)
-  const [isTokenRecovering, setIsTokenRecovering] = useState(true)
+  const [isAuthDataRecovering, setIsAuthDataRecovering] = useState(true)
 
   const storeToken = useCallback(value => {
     localStorage.setItem(TOKEN_KEY, JSON.stringify(value))
@@ -29,6 +29,7 @@ export const AuthentificationContextProvider = props => {
     try {
       const getUserRole = await authentificationRole(token)
       setUserRole(getUserRole.role)
+      setIsAuthDataRecovering(false)
     } catch {
       setUserRole(null)
     }
@@ -39,9 +40,9 @@ export const AuthentificationContextProvider = props => {
     const t = getStoredToken()
     if (t) {
       setToken(t)
+    } else {
+      setIsAuthDataRecovering(false)
     }
-
-    setIsTokenRecovering(false)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
@@ -53,9 +54,9 @@ export const AuthentificationContextProvider = props => {
   const value = useMemo(() => ({
     userRole,
     token,
-    isTokenRecovering,
+    isTokenRecovering: isAuthDataRecovering,
     storeToken
-  }), [userRole, token, isTokenRecovering, storeToken])
+  }), [userRole, token, isAuthDataRecovering, storeToken])
 
   return (
     <AuthentificationContext.Provider

--- a/pages/gestion-suivi.js
+++ b/pages/gestion-suivi.js
@@ -1,5 +1,6 @@
 import {useState, useContext, useEffect} from 'react'
 import Image from 'next/image'
+import {useRouter} from 'next/router'
 
 import AuthentificationContext from '@/contexts/authentification-token.js'
 
@@ -10,6 +11,7 @@ import Porteurs from '@/components/gestion-admin/porteurs.js'
 import Changes from '@/components/gestion-admin/changes.js'
 
 const Admin = () => {
+  const router = useRouter()
   const {userRole, token, isTokenRecovering} = useContext(AuthentificationContext)
 
   const [activeTab, setActiveTab] = useState('porteurs')
@@ -25,7 +27,12 @@ const Admin = () => {
 
   return (
     <Page>
-      {isModalOpen && <AdminAuthentificationModal handleModalOpen={setIsModalOpen} />}
+      {isModalOpen && (
+        <AdminAuthentificationModal
+          handleIsModalOpen={setIsModalOpen}
+          onModalClose={() => isUnauthentified ? router.push('/suivi-pcrs') : setIsModalOpen(false)}
+        />
+      )}
 
       <div className='page-header fr-my-5w'>
         <Image
@@ -106,5 +113,4 @@ const Admin = () => {
   )
 }
 
-Admin.propTypes = {}
 export default Admin

--- a/pages/gestion-suivi.js
+++ b/pages/gestion-suivi.js
@@ -1,5 +1,4 @@
-import {useState, useContext} from 'react'
-import {useRouter} from 'next/router'
+import {useState, useContext, useEffect} from 'react'
 import Image from 'next/image'
 
 import AuthentificationContext from '@/contexts/authentification-token.js'
@@ -11,16 +10,22 @@ import Porteurs from '@/components/gestion-admin/porteurs.js'
 import Changes from '@/components/gestion-admin/changes.js'
 
 const Admin = () => {
-  const router = useRouter()
   const {userRole, token, isTokenRecovering} = useContext(AuthentificationContext)
 
   const [activeTab, setActiveTab] = useState('porteurs')
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const isUnauthentified = !isTokenRecovering && (!token || (token && userRole !== 'admin'))
+
+  useEffect(() => {
+    if (isUnauthentified) {
+      setIsModalOpen(true)
+    }
+  }, [isUnauthentified])
 
   return (
     <Page>
-      {(userRole !== 'admin' || (!isTokenRecovering && !token)) && (
-        <AdminAuthentificationModal handleModalClose={() => router.push('/gestion-suivi')} />
-      )}
+      {isModalOpen && <AdminAuthentificationModal handleModalOpen={setIsModalOpen} />}
 
       <div className='page-header fr-my-5w'>
         <Image

--- a/pages/gestion-suivi.js
+++ b/pages/gestion-suivi.js
@@ -17,20 +17,22 @@ const Admin = () => {
   const [activeTab, setActiveTab] = useState('porteurs')
   const [isModalOpen, setIsModalOpen] = useState(false)
 
-  const isUnauthentified = !isTokenRecovering && (!token || (token && userRole !== 'admin'))
+  const isAuthentified = Boolean(token && userRole === 'admin')
 
   useEffect(() => {
-    if (isUnauthentified) {
+    if (!isTokenRecovering && !isAuthentified) {
       setIsModalOpen(true)
+    } else {
+      setIsModalOpen(false)
     }
-  }, [isUnauthentified])
+  }, [isAuthentified, isTokenRecovering])
 
   return (
     <Page>
       {isModalOpen && (
         <AdminAuthentificationModal
           handleIsModalOpen={setIsModalOpen}
-          onModalClose={() => isUnauthentified ? router.push('/suivi-pcrs') : setIsModalOpen(false)}
+          onModalClose={() => isAuthentified ? setIsModalOpen(false) : router.push('/suivi-pcrs')}
         />
       )}
 


### PR DESCRIPTION
Malgré la présence d'un token administrateur, la modale de connexion apparaissait quelques secondes le temps de la récupération du token.

Ce fix permet de n'afficher la modale d'authentification seulement une fois que toutes les données requises sont récupérées (token + rôle de l'utilisateur) et que cela est nécessaire.


### **Problème initial**
https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/e57f49e2-00cf-4de1-8a99-c2f092ed887e

