### PR TITLE
Modification nom de props pour la modale d'authentification

### DIFF
--- a/components/map-sidebar/project-header.js
+++ b/components/map-sidebar/project-header.js
@@ -93,7 +93,7 @@ const Header = ({projectId, codeEditor, projectName, territoires, projets, onPro
                 isSidebar
                 nom={projectName}
                 id={projectId}
-                authorisationCode={token}
+                authorizationCode={token}
                 handleDeleteModalOpen={handleDeleteModalOpen}
               />
             )}

--- a/components/map-sidebar/project-header.js
+++ b/components/map-sidebar/project-header.js
@@ -93,7 +93,7 @@ const Header = ({projectId, codeEditor, projectName, territoires, projets, onPro
                 isSidebar
                 nom={projectName}
                 id={projectId}
-                token={token}
+                authorisationCode={token}
                 handleDeleteModalOpen={handleDeleteModalOpen}
               />
             )}

--- a/components/suivi-form/delete-modal.js
+++ b/components/suivi-form/delete-modal.js
@@ -10,7 +10,7 @@ import colors from '@/styles/colors.js'
 import Button from '@/components/button.js'
 import Modal from '@/components/modal.js'
 
-const DeleteModal = ({nom, id, token, isSidebar, handleDeleteModalOpen}) => {
+const DeleteModal = ({nom, id, authorisationCode, isSidebar, handleDeleteModalOpen}) => {
   const router = useRouter()
 
   const [validationMessage, setValidationMessage] = useState(null)
@@ -21,7 +21,7 @@ const DeleteModal = ({nom, id, token, isSidebar, handleDeleteModalOpen}) => {
     setErrorMessage(null)
 
     try {
-      await deleteSuivi(id, token)
+      await deleteSuivi(id, authorisationCode)
 
       setValidationMessage('le projet a bien été supprimé')
       setTimeout(() => {
@@ -90,7 +90,7 @@ const DeleteModal = ({nom, id, token, isSidebar, handleDeleteModalOpen}) => {
 DeleteModal.propTypes = {
   nom: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
-  token: PropTypes.string.isRequired,
+  authorisationCode: PropTypes.string.isRequired,
   handleDeleteModalOpen: PropTypes.func.isRequired,
   isSidebar: PropTypes.bool
 }

--- a/components/suivi-form/delete-modal.js
+++ b/components/suivi-form/delete-modal.js
@@ -10,7 +10,7 @@ import colors from '@/styles/colors.js'
 import Button from '@/components/button.js'
 import Modal from '@/components/modal.js'
 
-const DeleteModal = ({nom, id, authorisationCode, isSidebar, handleDeleteModalOpen}) => {
+const DeleteModal = ({nom, id, authorizationCode, isSidebar, handleDeleteModalOpen}) => {
   const router = useRouter()
 
   const [validationMessage, setValidationMessage] = useState(null)
@@ -21,7 +21,7 @@ const DeleteModal = ({nom, id, authorisationCode, isSidebar, handleDeleteModalOp
     setErrorMessage(null)
 
     try {
-      await deleteSuivi(id, authorisationCode)
+      await deleteSuivi(id, authorizationCode)
 
       setValidationMessage('le projet a bien été supprimé')
       setTimeout(() => {
@@ -90,7 +90,7 @@ const DeleteModal = ({nom, id, authorisationCode, isSidebar, handleDeleteModalOp
 DeleteModal.propTypes = {
   nom: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
-  authorisationCode: PropTypes.string.isRequired,
+  authorizationCode: PropTypes.string.isRequired,
   handleDeleteModalOpen: PropTypes.func.isRequired,
   isSidebar: PropTypes.bool
 }

--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -97,8 +97,8 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
           subventions: projetSubventions
         }
 
-        const authorisationCode = editionCode || token
-        const sendSuivi = _id ? await editProject(suivi, _id, authorisationCode) : await postSuivi(suivi, token)
+        const authorizationCode = editionCode || token
+        const sendSuivi = _id ? await editProject(suivi, _id, authorizationCode) : await postSuivi(suivi, token)
 
         setEditedProjectId(sendSuivi._id)
         setEditCode(sendSuivi.editorKey)
@@ -282,7 +282,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
               <DeleteModal
                 nom={nom}
                 id={_id}
-                authorisationCode={editionCode}
+                authorizationCode={editionCode}
                 handleDeleteModalOpen={handleDeleteModalOpen}
               />
             )}

--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -282,7 +282,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
               <DeleteModal
                 nom={nom}
                 id={_id}
-                token={editionCode}
+                authorisationCode={editionCode}
                 handleDeleteModalOpen={handleDeleteModalOpen}
               />
             )}


### PR DESCRIPTION
Le composant `<DeleteModal />` recevait une prop nommée `token` mais qui pouvait être à la fois le token administrateur/créateur et le code d'édition. 

Ce nom rendait le code peu compréhensible. La prop est renommée `authorisationCode` pour plus de clarté.