### PR TITLE
Mise à jour de la légende de la carte 

### DIFF
--- a/components/map/legend.js
+++ b/components/map/legend.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import {PCRS_DATA_COLORS} from '@/styles/pcrs-data-colors.js'
 import Badge from '@/components/badge.js'
 
-const Legend = ({isMobile}) => {
-  const {status} = PCRS_DATA_COLORS
+const Legend = ({isMobile, legend}) => {
+  const {status, natures} = PCRS_DATA_COLORS
   const [isOpen, setIsOpen] = useState(!isMobile)
 
   return (
@@ -22,11 +22,22 @@ const Legend = ({isMobile}) => {
       {isOpen ? (
         <>
           <span><u>Légende :</u></span>
-          <Badge className='fr-pb-1v fr-pt-1v' size='small' background={status.investigation}>Investigation</Badge>
-          <Badge className='fr-pb-1v' size='small' background={status.production}>Production</Badge>
-          <Badge className='fr-pb-1v' size='small' background={status.produit}>Produit</Badge>
-          <Badge className='fr-pb-1v' size='small' background={status.livre} textColor='snow'>Livré</Badge>
-          <Badge className='fr-pb-2v' size='small' background={status.obsolete} textColor='snow'>Obsolète</Badge>
+          {(legend === 'departements-fills' || !legend) && (
+            <>
+              <Badge className='fr-pb-1v fr-pt-1v' size='small' background={status.investigation}>Investigation</Badge>
+              <Badge className='fr-pb-1v' size='small' background={status.production}>Production</Badge>
+              <Badge className='fr-pb-1v' size='small' background={status.produit}>Produit</Badge>
+              <Badge className='fr-pb-1v' size='small' background={status.livre} textColor='snow'>Livré</Badge>
+              <Badge className='fr-pb-2v' size='small' background={status.obsolete} textColor='snow'>Obsolète</Badge>
+            </>
+          )}
+          {legend === 'departements-fills-nature' && (
+            <>
+              <Badge className='fr-pb-1v fr-pt-1v' size='small' background={natures.vecteur}>Vecteur</Badge>
+              <Badge className='fr-pb-1v' size='small' background={natures.raster}>Raster</Badge>
+              <Badge className='fr-pb-2v' size='small' background={natures.mixte}>Mixte</Badge>
+            </>
+          )}
           <hr className='fr-p-1v' />
           <span
             className='fr-icon--sm fr-icon-close-circle-line'
@@ -57,12 +68,13 @@ const Legend = ({isMobile}) => {
 }
 
 Legend.defaultProps = {
-  isMobile: true
+  isMobile: true,
+  legend: 'departements-fills'
 }
 
 Legend.propTypes = {
-  isMobile: PropTypes.bool
+  isMobile: PropTypes.bool,
+  legend: PropTypes.string
 }
 
 export default Legend
-


### PR DESCRIPTION
Les couleurs de la carte de suivi de projet ont été mises à jour avec la PR #225, mais la légende n'a pas été mise à jour.

Cette PR ajoute une nouvelle légende synchronisée avec les couleurs de la carte de suivi.

Fix #227 

Capture : 

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/d6244c2d-ac92-4ee4-89c1-f41e66b0489e)
