### PR TITLE
Ajout d'un point d'entrée vers la page administrateur

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -1,111 +1,100 @@
-import {useState} from 'react'
 import Link from 'next/link'
 
-import AdminAuthentificationModal from '@/components/suivi-form/authentification/admin-authentification-modal.js'
-
-const Footer = () => {
-  const [isAuthentificationModalOpen, setIsAuthentificationModalOpen] = useState(false)
-
-  return (
-    <>
-      <footer className='fr-footer' role='contentinfo' id='footer'>
-        <div className='fr-container'>
-          <div className='fr-footer__body'>
-            <div className='fr-footer__brand fr-enlarge-link'>
-              <Link href='/' title='Retour à l’accueil du site - PCRS'>
-                <p className='fr-logo'>
-                  République<br />Française
-                </p>
-              </Link>
-            </div>
-            <div className='fr-footer__content'>
-              <ul className='fr-footer__content-list'>
-                <li className='fr-footer__content-item'>
-                  <a
-                    className='fr-footer__content-link'
-                    target='_blank'
-                    href='https://legifrance.gouv.fr'
-                    rel='noreferrer'
-                  >
-                    legifrance.gouv.fr
-                  </a>
-                </li>
-                <li className='fr-footer__content-item'>
-                  <a
-                    className='fr-footer__content-link'
-                    target='_blank'
-                    href='https://gouvernement.fr'
-                    rel='noreferrer'
-                  >
-                    gouvernement.fr
-                  </a>
-                </li>
-                <li className='fr-footer__content-item'>
-                  <a
-                    className='fr-footer__content-link'
-                    target='_blank'
-                    href='https://service-public.fr'
-                    rel='noreferrer'
-                  >
-                    service-public.fr
-                  </a>
-                </li>
-                <li className='fr-footer__content-item'>
-                  <a
-                    className='fr-footer__content-link'
-                    target='_blank'
-                    href='https://data.gouv.fr'
-                    rel='noreferrer'
-                  >
-                    data.gouv.fr
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-          <div className='fr-footer__bottom'>
-            <ul className='fr-footer__bottom-list'>
-              <li className='fr-footer__bottom-item'>
-                <button
-                  className='fr-footer__bottom-link'
-                  type='button'
-                  label='Accéder à au panneau d’authentification'
-                  onClick={() => setIsAuthentificationModalOpen(true)}
-                >
-                  Accès administrateur
-                </button>
-              </li>
-              <li className='fr-footer__bottom-item'>
-                <Link
-                  href='/declaration-accessibilite'
-                  title='Déclaration d’accessibilité'
-                  className='fr-footer__bottom-link'
-                >
-                  Déclaration d’accessibilité : non-conforme
-                </Link>
-              </li>
-              <li className='fr-footer__bottom-item'>
-                <Link
-                  href='/mentions-legales'
-                  title='Mentions légales'
-                  className='fr-footer__bottom-link'
-                >
-                  Mentions légales
-                </Link>
-              </li>
-            </ul>
-            <div className='fr-footer__bottom-copy'>
-              <p>
-                Sauf mention contraire, tous les contenus de ce site sont sous <a href='https://github.com/etalab/licence-ouverte/blob/master/LO.md' target='_blank' rel='noreferrer'>licence etalab-2.0</a>
-              </p>
-            </div>
-          </div>
+const Footer = () => (
+  <footer className='fr-footer' role='contentinfo' id='footer'>
+    <div className='fr-container'>
+      <div className='fr-footer__body'>
+        <div className='fr-footer__brand fr-enlarge-link'>
+          <Link href='/' title='Retour à l’accueil du site - PCRS'>
+            <p className='fr-logo'>
+              République<br />Française
+            </p>
+          </Link>
         </div>
-      </footer>
-
-      {isAuthentificationModalOpen && <AdminAuthentificationModal handleIsModalOpen={setIsAuthentificationModalOpen} />}
-    </>
-  )
-}
+        <div className='fr-footer__content'>
+          <ul className='fr-footer__content-list'>
+            <li className='fr-footer__content-item'>
+              <a
+                className='fr-footer__content-link'
+                target='_blank'
+                href='https://legifrance.gouv.fr'
+                rel='noreferrer'
+              >
+                legifrance.gouv.fr
+              </a>
+            </li>
+            <li className='fr-footer__content-item'>
+              <a
+                className='fr-footer__content-link'
+                target='_blank'
+                href='https://gouvernement.fr'
+                rel='noreferrer'
+              >
+                gouvernement.fr
+              </a>
+            </li>
+            <li className='fr-footer__content-item'>
+              <a
+                className='fr-footer__content-link'
+                target='_blank'
+                href='https://service-public.fr'
+                rel='noreferrer'
+              >
+                service-public.fr
+              </a>
+            </li>
+            <li className='fr-footer__content-item'>
+              <a
+                className='fr-footer__content-link'
+                target='_blank'
+                href='https://data.gouv.fr'
+                rel='noreferrer'
+              >
+                data.gouv.fr
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div className='fr-footer__bottom'>
+        <ul className='fr-footer__bottom-list'>
+          <li className='fr-footer__bottom-item'>
+            <Link
+              href='/gestion-suivi'
+              className='fr-footer__bottom-link'
+              type='button'
+              label='Accéder à au panneau d’authentification'
+            >
+              Accès administrateur
+            </Link>
+          </li>
+          <li className='fr-footer__bottom-item'>
+            <Link
+              href='/declaration-accessibilite'
+              title='Déclaration d’accessibilité'
+              className='fr-footer__bottom-link'
+            >
+              Déclaration d’accessibilité : non-conforme
+            </Link>
+          </li>
+          <li className='fr-footer__bottom-item'>
+            <Link
+              href='/mentions-legales'
+              title='Mentions légales'
+              className='fr-footer__bottom-link'
+            >
+              Mentions légales
+            </Link>
+          </li>
+        </ul>
+        <div className='fr-footer__bottom-copy'>
+          <p>
+            Sauf mention contraire, tous les contenus de ce site sont sous <a href='https://github.com/etalab/licence-ouverte/blob/master/LO.md' target='_blank' rel='noreferrer'>licence etalab-2.0</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </footer>
+)
 
 export default Footer

--- a/components/suivi-form/authentification/admin-authentification-modal.js
+++ b/components/suivi-form/authentification/admin-authentification-modal.js
@@ -86,11 +86,7 @@ const AdminAuthentificationModal = ({handleIsModalOpen, onModalClose}) => {
 
 AdminAuthentificationModal.propTypes = {
   handleIsModalOpen: PropTypes.func.isRequired,
-  onModalClose: PropTypes.func
-}
-
-AdminAuthentificationModal.defaultProps = {
-  onModalClose() {}
+  onModalClose: PropTypes.func.isRequired
 }
 
 export default AdminAuthentificationModal


### PR DESCRIPTION
"Accès administrateur" dans le `footer` redirige à présent vers la page `/gestion-suivi` au lieu d'ouvrir la modale d'authentification.

<img width="704" alt="Capture d’écran 2023-06-21 à 17 09 02" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/45be301f-391b-4fbd-b309-796c7ef31641">
