### PR TITLE
Lien vers la page des événements dans le bandeau

### DIFF
--- a/components/event-carousel.js
+++ b/components/event-carousel.js
@@ -1,4 +1,5 @@
 import {useState, useEffect} from 'react'
+import Link from 'next/link'
 
 import allEvents from '../events.json'
 
@@ -48,11 +49,13 @@ const EventCarousel = () => {
         <ul className='slider'>
           {events.map((event, idx) => (
             <li key={`${event.title}-${event.date}`} className={idx === index ? 'slide' : 'hidden'}>
-              <div className='fr-text--lg fr-m-0'>
-                {event.title}
-              </div>
+              <Link legacyBehavior href='/evenements'>
+                <a className='fr-text--lg fr-m-0'>
+                  {event.title}
+                </a>
+              </Link>
 
-              <div className='date'>le {dateWithDay(event.date)}</div>
+              <div className='date fr-mt-1w'>le {dateWithDay(event.date)}</div>
             </li>
           )
           )}


### PR DESCRIPTION
Le slider sur la page d'accueil faisant défiler les prochains événements dispose à présent d'un lien vers la page des événements.

### **AVANT**
<img width="1439" alt="Capture d’écran 2023-06-21 à 17 15 45" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/26267c68-b185-475b-81ae-ceb5ad54b55c">

### **APRÈS**
<img width="1440" alt="Capture d’écran 2023-06-21 à 17 16 35" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/266dd846-3f7f-428b-9acf-cda30d93874a">