### PR TITLE
Imposer la présence d'un acteur porteur

### DIFF
--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -46,14 +46,16 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
   const [projetEtapes, setProjetEtapes] = useState(etapes)
   const [projetSubventions, setProjetSubventions] = useState(subventions || [])
 
-  const hasMissingData = projetLivrables.length === 0 || projetActeurs.length === 0 || projetPerimetres.length === 0
+  const hasMissingRequiredItems = projetLivrables.length === 0 || projetActeurs.length === 0 || projetPerimetres.length === 0
+  const isPorteurMissing = Boolean(!projetActeurs.some(acteur => acteur.role === 'aplc' || acteur.role === 'porteur'))
+
   const handleDeleteModalOpen = () => setIsDeleteModalOpen(!isDeleteModalOpen)
 
   useEffect(() => {
-    if (!hasMissingData && !isRequiredFormOpen) {
+    if (!hasMissingRequiredItems && !isRequiredFormOpen) {
       setErrorMessage(null)
     }
-  }, [hasMissingData, isRequiredFormOpen])
+  }, [hasMissingRequiredItems, isRequiredFormOpen])
 
   const handleAuthentificationModal = () => router.push('/suivi-pcrs')
   const handleModal = () => router.push('/suivi-pcrs')
@@ -81,10 +83,13 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
         return setErrorMessage('Veuiller valider ou annuler le livrable, l’acteur ou le périmètre en cours d’ajout.')
       }
 
-      if (hasMissingData) {
+      if (hasMissingRequiredItems) {
         setHasMissingItemsOnValidation(true)
         handleScrollToError()
         setErrorMessage('Des données nécessaires à la validation du formulaires sont manquantes. Au moins un livrable, un acteur et un périmètre doivent être ajoutés.')
+      } else if (isPorteurMissing) {
+        setHasMissingItemsOnValidation(true)
+        setErrorMessage('Au moins un des acteurs doit avoir le rôle de porteur de projet.')
       } else {
         const suivi = {
           nom: suiviNom,


### PR DESCRIPTION
À ce jour, la présence d'un porteur APLC ou d'un porteur non-APLC n'était pas requise à la validation du formulaire de suivi.
Or, il est obligatoire qu'un projet dispose d'un porteur.

Cette PR se concentre sur le blocage de la validation du formulaire et sur la gestion d'erreur en front dans le cas où est porteur n'a pas été ajouté.

À terme, cette vérification devra s'effectuer via le validateur.

<img width="678" alt="Capture d’écran 2023-06-22 à 11 28 29" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/0783b8e5-440c-4583-8538-6ce3d3d8c604">

Close  #222