### PR TITLE
Correction de l'ancre de la section contact

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -51,7 +51,7 @@ const Hero = () => (
         <Link
           passHref
           legacyBehavior
-          href='/#newsletter'
+          href='/#contact'
         >
           <a aria-label='Accéder à la section suivez de contact' className='fr-link illustrated-link fr-text--sm'>
             <Image


### PR DESCRIPTION
Le lien "prendre contact" dans le hero de la page d'accueil ne fonctionnait pas. 
À présent, il redirige correctement vers la section contact.