### PR TITLE
Adaptation de la largeur des items dans le composants <Autocomplete />

### DIFF
--- a/components/autocomplete-input.js
+++ b/components/autocomplete-input.js
@@ -69,6 +69,7 @@ const AutocompleteInput = ({
           box-shadow: 2px 12px 23px 2px rgba(0,0,0,0.23);
           border-radius: 0 0 5px 5px;
           background: white;
+          z-index: 2;
         }
 
         .hidden {

--- a/components/autocomplete-input.js
+++ b/components/autocomplete-input.js
@@ -64,6 +64,8 @@ const AutocompleteInput = ({
       <style jsx>{`
         .menu {
           position: absolute;
+          left: 0;
+          right: 0;
           box-shadow: 2px 12px 23px 2px rgba(0,0,0,0.23);
           border-radius: 0 0 5px 5px;
           background: white;
@@ -77,17 +79,25 @@ const AutocompleteInput = ({
   ), [isLoading])
 
   return (
-    <Autocomplete
-      value={value}
-      getItemValue={getItemValue}
-      items={results}
-      renderItem={(item, isHighlighted) => customItem(item, isHighlighted)}
-      renderMenu={customMenu}
-      renderInput={customInput}
-      wrapperStyle={{width: '100%'}}
-      onChange={onValueChange}
-      onSelect={onSelectValue}
-    />
+    <div className='search-input-wrapper'>
+      <Autocomplete
+        value={value}
+        getItemValue={getItemValue}
+        items={results}
+        renderItem={(item, isHighlighted) => customItem(item, isHighlighted)}
+        renderMenu={customMenu}
+        renderInput={customInput}
+        wrapperStyle={{width: '100%'}}
+        onChange={onValueChange}
+        onSelect={onSelectValue}
+      />
+
+      <style jsx>{`
+        .search-input-wrapper {
+          position: relative;
+        }
+      `}</style>
+    </div>
   )
 }
 

--- a/components/autocomplete-render-item.js
+++ b/components/autocomplete-render-item.js
@@ -11,6 +11,10 @@ const AutocompleteRenderItem = ({children, isHighlighted}) => (
         background: ${isHighlighted ? colors.blueHover : 'white'};
         color: ${isHighlighted ? 'white' : colors.darkgrey};
       }
+
+      .item:hover {
+        cursor : ${isHighlighted ? 'pointer' : 'auto'}
+      }
     `}</style>
   </div>
 )


### PR DESCRIPTION
La largeur du menu du composant `<Autocomplete />` s'adaptait à la taille de l'élément le plus grand.
La largeur s'adapte à présent à celle de l'input
### **AVANT**
<img width="711" alt="Capture d’écran 2023-07-10 à 14 51 59" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/db7675cb-abcf-4223-bdca-ead3882f3de5">

### **APRÈS**
<img width="723" alt="Capture d’écran 2023-07-10 à 14 51 37" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/8d4a9b29-80fe-41b6-9a66-b965c50dcfdd">
