### PR TITLE
Ajout de la couleur définissant le porteur

### DIFF
--- a/styles/pcrs-data-colors.js
+++ b/styles/pcrs-data-colors.js
@@ -27,6 +27,7 @@ export const PCRS_DATA_COLORS = {
   },
   actors: {
     aplc: '#fef7da',
+    porteur: '#FEDAE0',
     financeur: '#e6feda',
     diffuseur: '#dffdf7',
     presta_vol: '#c7f6fc',


### PR DESCRIPTION
L'acteur de type `porteur` ne bénéficiait pas d'une couleur afin de le distinguer dans la liste des acteurs dans la sidebar (page `/suivi-pcrs`)

### **AVANT**
<img width="455" alt="Capture d’écran 2023-07-10 à 15 11 43" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/ca382c1e-8906-442c-ace4-af0d793d6f2f">

### **APRÈS**
<img width="393" alt="Capture d’écran 2023-07-10 à 15 11 22" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/c1d7b956-3879-4c39-99b5-247a00df940b">
