### PR TITLE
Validation de l'ordre des dates des étapes des projets

### DIFF
--- a/lib/__tests__/projets-validator.js
+++ b/lib/__tests__/projets-validator.js
@@ -3,7 +3,7 @@
 
 import test from 'ava'
 import Joi from 'joi'
-import {validateCreation, validateChanges, validateJoiDate, validatePerimetre} from '../projets-validator.js'
+import {validateCreation, validateChanges, validateJoiDate, validatePerimetre, validateEtapesDates} from '../projets-validator.js'
 
 const validProjet = {
   nom: 'Projet Valide',
@@ -188,4 +188,26 @@ test('Joi/validateJoiDate : not valid', t => {
     const result = Joi.custom(validateJoiDate).validate(notValidDate)
     t.is(result.error.message, 'Date invalide')
   }
+})
+
+// Test validateEtapesDates
+
+test('Joi/validateEtapesDates : not valid', t => {
+  const result = Joi.custom(validateEtapesDates).validate([
+    {statut: 'investigation', date_debut: '2023-07-16'},
+    {statut: 'production', date_debut: '2024-02-21'},
+    {statut: 'produit', date_debut: '2023-07-28'}
+  ])
+
+  t.is(result.error.message, 'L’ordre des étapes est incorrect')
+})
+
+test('Joi/validateEtapesDates : valid', t => {
+  const result = Joi.custom(validateEtapesDates).validate([
+    {statut: 'investigation', date_debut: '2023-07-16'},
+    {statut: 'production', date_debut: '2023-07-28'},
+    {statut: 'produit', date_debut: '2023-08-28'}
+  ])
+
+  t.is(result.value.length, 3)
 })

--- a/lib/__tests__/projets-validator.js
+++ b/lib/__tests__/projets-validator.js
@@ -33,7 +33,7 @@ const validProjet = {
   ],
   perimetres: ['departement:08'],
   etapes: [
-    {statut: 'investigation', date_debut: null},
+    {statut: 'investigation', date_debut: '1999-01-11'},
     {statut: 'production', date_debut: '1999-02-11'},
     {statut: 'livre', date_debut: '2010-10-12'}
   ],

--- a/lib/projets-validator.js
+++ b/lib/projets-validator.js
@@ -31,6 +31,22 @@ export function validateJoiDate(date, helpers) {
   return date
 }
 
+export function validateEtapesDates(etapes, helpers) {
+  let hasError
+
+  etapes.forEach((etape, x) => {
+    if (x > 0 && new Date(etapes[x - 1].date_debut) > new Date(etape.date_debut)) {
+      hasError = true
+    }
+  })
+
+  if (hasError) {
+    return helpers.message('L’ordre des étapes est incorrect')
+  }
+
+  return etapes
+}
+
 const acteursSchemaCreation = Joi.object().keys({
   siren: Joi.number().required(),
   nom: Joi.string().allow(null),
@@ -206,7 +222,7 @@ const schemaUpdate = Joi.object({
   livrables: Joi.array().items(livrablesSchemaUpdate),
   acteurs: Joi.array().items(acteursSchemaUpdate),
   perimetres: Joi.array().items(Joi.string()),
-  etapes: Joi.array().items(etapesSchemaUpdate),
+  etapes: Joi.array().items(etapesSchemaUpdate).custom(validateEtapesDates),
   subventions: Joi.array().items(subventionsSchemaUpdate).allow(null)
 })
 

--- a/lib/projets-validator.js
+++ b/lib/projets-validator.js
@@ -133,7 +133,7 @@ const schemaCreation = Joi.object({
   livrables: Joi.array().items(livrablesSchemaCreation).required(),
   acteurs: Joi.array().items(acteursSchemaCreation).required(),
   perimetres: Joi.array().items(Joi.string().custom(validatePerimetre)).min(1).required(),
-  etapes: Joi.array().items(etapesSchemaCreation).required(),
+  etapes: Joi.array().items(etapesSchemaCreation).custom(validateEtapesDates).required(),
   subventions: Joi.array().items(subventionsSchemaCreation).required().allow(null)
 })
 

--- a/server/__tests__/projets.js
+++ b/server/__tests__/projets.js
@@ -59,7 +59,7 @@ const validProjet = {
     },
     {
       statut: 'production',
-      date_debut: null
+      date_debut: '2024-02-08'
     }
   ],
   subventions: [


### PR DESCRIPTION
Cette PR ajoute une fonction permettant la validation de l'ordre des dates des étapes de projet.
Elle permet d'éviter que l'utilisateur entre une date ultérieure à la précédente étapes.

- Ajout de la fonction `validateEtapesDates`
- Ajout de tests pour cette fonction