### PR TITLE
Gestion du message d'erreur pour les étapes (formulaire de suivi)

### DIFF
--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -116,8 +116,10 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
             const sortedErrors = sortBy(sendSuivi.validationErrors, error => error.context.key)
             sortedErrors.map(error => {
               let message
+              const handleContextMessage = (error.context.value || Array.isArray(error.context.value)) ? '' : error.context.value
+
               if (PAYLOAD_ERRORS[error.context.key]) {
-                message = `Section ${error.path[0]} - ${PAYLOAD_ERRORS[error.context.key]} ${error.context.value ? `: ${error.context.value}` : ''}`
+                message = `Section ${error.path[0]} - ${PAYLOAD_ERRORS[error.context.key]} ${handleContextMessage}`
               }
 
               return payloadErrors.push(message)

--- a/components/suivi-form/utils/payload-errors.js
+++ b/components/suivi-form/utils/payload-errors.js
@@ -13,5 +13,6 @@ export const PAYLOAD_ERRORS = {
   finance_part_euro: 'La part de financement suivante est invalide',
   finance_part_perc: 'Le montant du financement suivant est invalide',
   siren: 'Un numéro SIREN est manquant ou invalide',
-  role: 'Un rôle n’a pas été sélectionnée'
+  role: 'Un rôle n’a pas été sélectionnée',
+  etapes: 'Une incohérence a été détecté dans l’ordre des dates'
 }


### PR DESCRIPTION
⚠️ À merger avec la PR Validation de l'ordre des dates des étapes des projets [#244 ](https://github.com/openpcrs/pcrs.beta.gouv.fr/pull/244) (partie back, gestion via le validateur)

Cette PR constitue la partie front de la problématique évoquée dans l'issue [Evaluer la cohérence des dates du calendrier du formulaire #238 ](https://github.com/openpcrs/pcrs.beta.gouv.fr/pull/244). Permet l'interprétation et l'affichage d'un message d'erreur compréhensible par l'utilisateur en cas d'erreur dans l'ordre des dates des étapes dans le formulaire de suivi du PCRS.

<img width="1004" alt="Capture d’écran 2023-07-12 à 11 27 42" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/fe4278a8-2af0-4907-88f8-f405abab9394">
