### PR TITLE
Correction du type initial du montant de subvention

### DIFF
--- a/components/suivi-form/subventions/subvention-form.js
+++ b/components/suivi-form/subventions/subvention-form.js
@@ -107,7 +107,7 @@ const SubventionForm = ({subventions, updatingSubvIdx, isEditing, handleSubventi
       setNom(subvToUpdate.nom)
       setNature(subvToUpdate.nature)
       setEcheance(subvToUpdate.echeance || '')
-      setMontant(subvToUpdate.montant || '')
+      setMontant(subvToUpdate.montant.toString() || '')
 
       setUpdatingName(subvToUpdate.nom)
     }


### PR DESCRIPTION
Lors de l'ouverture du formulaire de suivi en "mode édition", le champ `montant` s'attend à une valeur de type `string`. Or l'api renvoie une valeur de type `number`, ce qui déclenchait un warning.

La valeur est à présent convertie en une `string` au moment de sa récupération.

Message d'erreur : 
`Warning: Failed prop type: Invalid prop `value` of type `number` supplied to `NumberInput`, expected `string``