### PR TITLE
Stocker les fonctions avec debounce dans un useRef

### DIFF
--- a/components/suivi-form/acteurs/acteur-form.js
+++ b/components/suivi-form/acteurs/acteur-form.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import {useState, useCallback, useEffect, useMemo} from 'react'
+import {useState, useCallback, useEffect, useMemo, useRef} from 'react'
 import PropTypes from 'prop-types'
 import {debounce, pick} from 'lodash-es'
 
@@ -203,7 +203,7 @@ const ActeurForm = ({acteurs, updatingActorIndex, isEditing, handleActorIndex, h
     }
   }, [isEditing, updatingActorIndex, acteurs, onRequiredFormOpen, setFinEuros, setSiren, setPhone, setMail, setFinPerc, setRole, setNom])
 
-  const fetchActors = useCallback(debounce(async (nom, signal) => { // eslint-disable-line react-hooks/exhaustive-deps
+  const fetchActors = useRef(debounce(async (nom, signal) => {
     setIsLoading(true)
     setSearchErrorMessage(null)
 
@@ -222,7 +222,7 @@ const ActeurForm = ({acteurs, updatingActorIndex, isEditing, handleActorIndex, h
     }
 
     setIsLoading(false)
-  }, 300), [setIsLoading, setFoundEtablissements])
+  }, 300))
 
   useEffect(() => {
     if (!nom || nom.length < 3) {
@@ -231,7 +231,7 @@ const ActeurForm = ({acteurs, updatingActorIndex, isEditing, handleActorIndex, h
     }
 
     const ac = new AbortController()
-    fetchActors(nom, ac.signal)
+    fetchActors.current(nom, ac.signal)
 
     return () => {
       ac.abort()

--- a/components/suivi-form/perimetres/perimetre-form.js
+++ b/components/suivi-form/perimetres/perimetre-form.js
@@ -1,4 +1,4 @@
-import {useState, useCallback, useEffect, useMemo} from 'react'
+import {useState, useCallback, useEffect, useMemo, useRef} from 'react'
 import PropTypes from 'prop-types'
 import {debounce} from 'lodash-es'
 
@@ -128,7 +128,7 @@ const PerimetreForm = ({perimetres, handlePerimetres, isEditing, perimetreAsObje
     }
   }, [perimetres, isEditing, perimetreAsObject, updatingPerimetreIdx, onRequiredFormOpen, setSearchValue, setType])
 
-  const fetchPerimetres = useCallback(debounce(async (nom, type, signal) => { // eslint-disable-line react-hooks/exhaustive-deps
+  const fetchPerimetres = useRef(debounce(async (nom, type, signal) => {
     setIsLoading(true)
 
     const inputToNumber = Number.parseInt(nom, 10)
@@ -151,7 +151,7 @@ const PerimetreForm = ({perimetres, handlePerimetres, isEditing, perimetreAsObje
     }
 
     setIsLoading(false)
-  }, 300), [setFoundPerimetres, setIsLoading])
+  }, 300))
 
   useEffect(() => {
     if (!searchValue || searchValue.length < 3) {


### PR DESCRIPTION
Le debounce ne s'effectuant qu'une seule fois, il est nécessaire de sauvegarder la fonction employant le `debounce` dans une ref, qui permet de sauvegarder une valeur indépendamment du cycle de vie du composant.

Close #251