### PR TITLE
Amélioration de la mise à jour de la liste des porteurs

### DIFF
--- a/components/gestion-admin/new-porter-form.js
+++ b/components/gestion-admin/new-porter-form.js
@@ -1,6 +1,5 @@
 import {useState} from 'react'
 import PropTypes from 'prop-types'
-import {useRouter} from 'next/router'
 
 import {addCreator} from '@/lib/suivi-pcrs.js'
 
@@ -9,9 +8,7 @@ import colors from '@/styles/colors.js'
 import TextInput from '@/components/text-input.js'
 import Button from '@/components/button.js'
 
-const NewPorteurForm = ({token, onClose}) => {
-  const router = useRouter()
-
+const NewPorteurForm = ({token, onClose, onRefetch}) => {
   const [validationMessage, setValidationMessage] = useState(null)
   const [errorMessage, setErrorMessage] = useState(null)
 
@@ -29,7 +26,8 @@ const NewPorteurForm = ({token, onClose}) => {
       setValidationMessage(`${nom} a été ajouté à la liste des porteurs autorisés`)
 
       setTimeout(() => {
-        router.reload(window.location.pathname)
+        onRefetch()
+        onClose()
       }, 1000)
     } catch (error) {
       setErrorMessage('Le nouveau porteur n’a pas pu être ajouté : ' + error)
@@ -98,7 +96,8 @@ const NewPorteurForm = ({token, onClose}) => {
 
 NewPorteurForm.propTypes = {
   token: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired
+  onClose: PropTypes.func.isRequired,
+  onRefetch: PropTypes.func.isRequired
 }
 
 export default NewPorteurForm

--- a/components/gestion-admin/porteur-card.js
+++ b/components/gestion-admin/porteur-card.js
@@ -1,6 +1,5 @@
 import {useState} from 'react'
 import PropTypes from 'prop-types'
-import {useRouter} from 'next/router'
 
 import colors from '@/styles/colors.js'
 
@@ -9,9 +8,7 @@ import {shortDate} from '@/lib/date-utils.js'
 
 import Modal from '@/components/modal.js'
 
-const PorteurCard = ({_id, email, nom, _created, token}) => {
-  const router = useRouter()
-
+const PorteurCard = ({_id, email, nom, _created, token, onRefetch}) => {
   const [errorMessage, setErrorMessage] = useState(null)
   const [validationMessage, setValidationMessage] = useState(null)
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false)
@@ -20,10 +17,6 @@ const PorteurCard = ({_id, email, nom, _created, token}) => {
     setIsConfirmationModalOpen(!isConfirmationModalOpen)
     setErrorMessage(null)
     setValidationMessage(null)
-
-    if (validationMessage) {
-      router.reload(window.location.pathname)
-    }
   }
 
   const onRevoke = async () => {
@@ -34,7 +27,8 @@ const PorteurCard = ({_id, email, nom, _created, token}) => {
       setValidationMessage(`Les droits de création de ${nom} ont été révoqués`)
 
       setTimeout(() => {
-        router.reload(window.location.pathname)
+        onRefetch()
+        setIsConfirmationModalOpen(!isConfirmationModalOpen)
       }, 2000)
     } catch {
       setErrorMessage(`Les droits de création de ${nom} n’ont pas été révoqués`)
@@ -162,7 +156,8 @@ PorteurCard.propTypes = {
   email: PropTypes.string.isRequired,
   nom: PropTypes.string,
   _created: PropTypes.string.isRequired,
-  token: PropTypes.string.isRequired
+  token: PropTypes.string.isRequired,
+  onRefetch: PropTypes.func.isRequired
 }
 
 export default PorteurCard

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -94,6 +94,7 @@ const Porteurs = () => {
         <NewPorteurForm
           token={token}
           onClose={handleFormOpen}
+          onRefetch={getPorteurs}
         />
       )}
 
@@ -126,7 +127,13 @@ const Porteurs = () => {
       {filteredPorteurs.length > 0 ? (
         <ul className='fr-mt-2w fr-p-0'>
           {filteredPorteurs.map(porteur => (
-            <li key={porteur._id} className='fr-my-2w'><PorteurCard token={token} {...porteur} /></li>
+            <li key={porteur._id} className='fr-my-2w'>
+              <PorteurCard
+                token={token}
+                onRefetch={getPorteurs}
+                {...porteur}
+              />
+            </li>
           ))}
         </ul>
       ) : (


### PR DESCRIPTION
Dans la page` /gestion-suivi`, lorsqu'un administrateur ajoute ou révoque un porteur, la page est refresh afin d'obtenir une liste des porteurs à jour.

Cette méthode est remplacée au profit d'un simple appel à l'API permettant de récupérer la liste à jour sans avoir besoin de rafraichir l'entièrement de la page. Ainsi la page ne verra pas ses états remis à 0. 