### PR TITLE
Fonction de tri insensible à la casse

### DIFF
--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import {orderBy} from 'lodash-es'
 
-import {normalizeSort} from '@/components/gestion-admin/utils/index.js'
+import {normalizeSort} from '@/lib/string.js'
 
 import Button from '@/components/button.js'
 import SelectInput from '@/components/select-input.js'

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -32,7 +32,7 @@ const Header = ({token, items, isAdmin, handleFilteredItems}) => {
 
   useEffect(() => {
     if (orderValue === 'alpha') {
-      handleFilteredItems(orderBy(items, [item => item.nom ? normalizeSort(item.nom) : normalizeSort('N/A')], ['asc']))
+      handleFilteredItems(orderBy(items, [item => normalizeSort(normalizeSort(item.nom || 'N/A'))], ['asc']))
     }
 
     if (orderValue === 'asc') {

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -30,7 +30,7 @@ const Header = ({token, items, isAdmin, handleFilteredItems}) => {
 
   useEffect(() => {
     if (orderValue === 'alpha') {
-      handleFilteredItems(orderBy(items, ['nom'], ['asc']))
+      handleFilteredItems(orderBy(items, [item => item.nom ? item.nom.toLowerCase() : 'N/A'.toLowerCase()], ['asc']))
     }
 
     if (orderValue === 'asc') {

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -2,6 +2,8 @@ import {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import {orderBy} from 'lodash-es'
 
+import {normalizeSort} from '@/components/gestion-admin/utils/index.js'
+
 import Button from '@/components/button.js'
 import SelectInput from '@/components/select-input.js'
 import AddForm from '@/components/gestion-admin/add-form.js'
@@ -30,7 +32,7 @@ const Header = ({token, items, isAdmin, handleFilteredItems}) => {
 
   useEffect(() => {
     if (orderValue === 'alpha') {
-      handleFilteredItems(orderBy(items, [item => item.nom ? item.nom.toLowerCase() : 'N/A'.toLowerCase()], ['asc']))
+      handleFilteredItems(orderBy(items, [item => item.nom ? normalizeSort(item.nom) : normalizeSort('N/A')], ['asc']))
     }
 
     if (orderValue === 'asc') {

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -22,7 +22,7 @@ const Porteurs = () => {
     try {
       const getPorteurs = await getCreators(token)
 
-      setPorteurs(orderBy(getPorteurs, [item => item.nom ? normalizeSort(item.nom) : normalizeSort('N/A')], ['asc']))
+      setPorteurs(orderBy(getPorteurs, [item => normalizeSort(item.nom || 'N/A')], ['asc']))
     } catch {
       setErrorMessage('La liste des porteurs de projets n’a pas pu être récupérée')
     }

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -1,5 +1,5 @@
 import {useState, useEffect, useCallback, useContext} from 'react'
-import {orderBy} from 'lodash-es'
+import {orderBy} from 'lodash'
 
 import {getCreators} from '@/lib/suivi-pcrs.js'
 
@@ -20,10 +20,8 @@ const Porteurs = () => {
   const getPorteurs = useCallback(async () => {
     try {
       const getPorteurs = await getCreators(token)
-      const orderByName = orderBy(getPorteurs, ['nom'], ['asc'])
 
-      setPorteurs(orderByName)
-      setFilteredPorteurs(orderByName)
+      setPorteurs(orderBy(getPorteurs, [item => item.nom ? item.nom.toLowerCase() : 'N/A'.toLowerCase()], ['asc']))
     } catch {
       setErrorMessage('La liste des porteurs de projets n’a pas pu être récupérée')
     }

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -2,6 +2,7 @@ import {useState, useEffect, useCallback, useContext} from 'react'
 import {orderBy} from 'lodash'
 
 import {getCreators} from '@/lib/suivi-pcrs.js'
+import {normalizeSort} from '@/components/gestion-admin/utils/index.js'
 
 import PorteurList from '@/components/gestion-admin/porteur-list.js'
 import Header from '@/components/gestion-admin/header.js'
@@ -21,7 +22,7 @@ const Porteurs = () => {
     try {
       const getPorteurs = await getCreators(token)
 
-      setPorteurs(orderBy(getPorteurs, [item => item.nom ? item.nom.toLowerCase() : 'N/A'.toLowerCase()], ['asc']))
+      setPorteurs(orderBy(getPorteurs, [item => item.nom ? normalizeSort(item.nom) : normalizeSort('N/A')], ['asc']))
     } catch {
       setErrorMessage('La liste des porteurs de projets n’a pas pu être récupérée')
     }

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -2,7 +2,7 @@ import {useState, useEffect, useCallback, useContext} from 'react'
 import {orderBy} from 'lodash'
 
 import {getCreators} from '@/lib/suivi-pcrs.js'
-import {normalizeSort} from '@/components/gestion-admin/utils/index.js'
+import {normalizeSort} from '@/lib/string.js'
 
 import PorteurList from '@/components/gestion-admin/porteur-list.js'
 import Header from '@/components/gestion-admin/header.js'

--- a/components/gestion-admin/utils/index.js
+++ b/components/gestion-admin/utils/index.js
@@ -1,6 +1,0 @@
-import {deburr} from 'lodash-es'
-
-export function normalizeSort(nom) {
-  return deburr(nom.toLowerCase())
-}
-

--- a/components/gestion-admin/utils/index.js
+++ b/components/gestion-admin/utils/index.js
@@ -1,0 +1,6 @@
+import {deburr} from 'lodash-es'
+
+export function normalizeSort(nom) {
+  return deburr(nom.toLowerCase())
+}
+

--- a/lib/string.js
+++ b/lib/string.js
@@ -1,0 +1,6 @@
+import {deburr} from 'lodash-es'
+
+export function normalizeSort(string) {
+  return deburr(string.toLowerCase())
+}
+


### PR DESCRIPTION
Dans la page de gestion de suivi, les porteurs peuvent être triés par ordre alphabétique ascendant.
Il a été remarqué que la fonction était sensible à la casse et qu'un nom en majuscule sera trié avant un nom en minuscule malgré l'ordre des premières lettres dans l'alphabet.

### **AVANT**
<img width="1029" alt="255154006-c708ec28-d339-4d12-ac31-829fcb5b88d2" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/ddfc9f03-0101-49ee-82be-d65268359581">

### **APRÈS**
<img width="1031" alt="Capture d’écran 2023-07-21 à 16 09 50" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/75ac0c57-50f8-45b0-b8c9-9c313368d7d5">

Close #258