### PR TITLE
Amélioration de la mise à jour de la liste des porteurs

### DIFF
--- a/components/gestion-admin/add-form.js
+++ b/components/gestion-admin/add-form.js
@@ -1,6 +1,5 @@
 import {useState} from 'react'
 import PropTypes from 'prop-types'
-import {useRouter} from 'next/router'
 
 import {addCreator} from '@/lib/suivi-pcrs.js'
 
@@ -9,9 +8,7 @@ import colors from '@/styles/colors.js'
 import TextInput from '@/components/text-input.js'
 import Button from '@/components/button.js'
 
-const AddForm = ({token, onClose}) => {
-  const router = useRouter()
-
+const AddForm = ({token, onClose, handleReloadData, handleFormOpen}) => {
   const [validationMessage, setValidationMessage] = useState(null)
   const [errorMessage, setErrorMessage] = useState(null)
 
@@ -29,7 +26,8 @@ const AddForm = ({token, onClose}) => {
       setValidationMessage(`${nom} a été ajouté à la liste des porteurs autorisés`)
 
       setTimeout(() => {
-        router.reload(window.location.pathname)
+        handleReloadData()
+        handleFormOpen()
       }, 1000)
     } catch (error) {
       setErrorMessage('Le nouveau porteur n’a pas pu être ajouté : ' + error)
@@ -98,7 +96,9 @@ const AddForm = ({token, onClose}) => {
 
 AddForm.propTypes = {
   token: PropTypes.string.isRequired,
-  onClose: PropTypes.func.isRequired
+  handleReloadData: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  handleFormOpen: PropTypes.func.isRequired
 }
 
 export default AddForm

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -12,7 +12,7 @@ const orderOptions = [
   {value: 'desc', label: 'Date d’ajout décroissante'}
 ]
 
-const Header = ({token, items, isAdmin, handleFilteredItems}) => {
+const Header = ({token, items, isAdmin, handleFilteredItems, handleReloadData}) => {
   const [orderValue, setOrderValue] = useState('alpha')
   const [searchValue, setSearchValue] = useState('')
   const [isFormOpen, setIsFormOpen] = useState(false)
@@ -56,7 +56,14 @@ const Header = ({token, items, isAdmin, handleFilteredItems}) => {
         Autoriser un {isAdmin ? 'nouvel admin' : 'nouveau porteur'}
       </Button>
 
-      {isFormOpen && <AddForm token={token} onClose={handleFormOpen} />}
+      {isFormOpen && (
+        <AddForm
+          token={token}
+          handleReloadData={handleReloadData}
+          handleFormOpen={() => setIsFormOpen(!isFormOpen)}
+          onClose={handleFormOpen}
+        />
+      )}
 
       <div className='fr-grid-row fr-grid-row--middle fr-mt-8w'>
         <div className='fr-col-12 fr-col-md-4'>
@@ -91,6 +98,7 @@ Header.propTypes = {
   token: PropTypes.string.isRequired,
   items: PropTypes.array.isRequired,
   isAdmin: PropTypes.bool,
+  handleReloadData: PropTypes.func.isRequired,
   handleFilteredItems: PropTypes.func.isRequired
 }
 

--- a/components/gestion-admin/porteur-list.js
+++ b/components/gestion-admin/porteur-list.js
@@ -1,15 +1,12 @@
 import {useState} from 'react'
 import PropTypes from 'prop-types'
-import {useRouter} from 'next/router'
 
 import {deleteCreator} from '@/lib/suivi-pcrs.js'
 
 import ListItem from '@/components/gestion-admin/list-item.js'
 import Modal from '@/components/modal.js'
 
-const PorteurList = ({token, porteurs}) => {
-  const router = useRouter()
-
+const PorteurList = ({token, porteurs, handleReloadPorteurs}) => {
   const [errorMessage, setErrorMessage] = useState(null)
   const [validationMessage, setValidationMessage] = useState(null)
   const [selectedPorteurId, setSelectedPorteurId] = useState(null)
@@ -32,7 +29,7 @@ const PorteurList = ({token, porteurs}) => {
       setValidationMessage(`Les droits de création de ${nom} ont été révoqués`)
 
       setTimeout(() => {
-        router.reload(window.location.pathname)
+        handleReloadPorteurs()
       }, 2000)
     } catch {
       setErrorMessage(`Les droits de création de ${nom} n’ont pas été révoqués`)
@@ -92,7 +89,8 @@ const PorteurList = ({token, porteurs}) => {
 
 PorteurList.propTypes = {
   token: PropTypes.string.isRequired,
-  porteurs: PropTypes.array.isRequired
+  porteurs: PropTypes.array.isRequired,
+  handleReloadPorteurs: PropTypes.func.isRequired
 }
 
 export default PorteurList

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -45,10 +45,15 @@ const Porteurs = () => {
         token={token}
         items={porteurs}
         handleFilteredItems={setFilteredPorteurs}
+        handleReloadData={getPorteurs}
       />
 
       {filteredPorteurs.length > 0 ? (
-        <PorteurList token={token} porteurs={filteredPorteurs} />
+        <PorteurList
+          token={token}
+          porteurs={filteredPorteurs}
+          handleReloadPorteurs={getPorteurs}
+        />
       ) : (
         <p className='fr-mt-4w'> <i>La liste des porteurs de projets autorisés est vide.</i></p>
       )}


### PR DESCRIPTION
Dans la page `/gestion-suivi`, lorsqu'un administrateur ajoute ou révoque un porteur, la page est rafraîchi afin d'obtenir une liste des porteurs à jour.

Cette méthode est remplacée au profit d'un simple appel à l'API permettant de récupérer la liste à jour sans avoir besoin de rafraichir l'entièrement de la page. 

Cette amélioration permet de gagner en fluidité. Elle permet aussi de préparer le terrain pour l'ajout de la gestion des administrateurs. Si l'utilisateur se trouve sur l'onglet `Administrateur` et effectue des changements, la page ne se rechargera pas et l'onglet restera sélectionné. Dans le cas contraire, l'utilisateur se retrouve par défaut de nouveau sur l'onglet `Porteurs`.
