### PR TITLE
Déplacer la fonction d'ajout de porteurs

### DIFF
--- a/components/gestion-admin/add-form.js
+++ b/components/gestion-admin/add-form.js
@@ -1,41 +1,17 @@
 import {useState} from 'react'
 import PropTypes from 'prop-types'
 
-import {addCreator} from '@/lib/suivi-pcrs.js'
-
 import colors from '@/styles/colors.js'
 
 import TextInput from '@/components/text-input.js'
 import Button from '@/components/button.js'
 
-const AddForm = ({token, onClose, handleReloadData, handleFormOpen}) => {
-  const [validationMessage, setValidationMessage] = useState(null)
-  const [errorMessage, setErrorMessage] = useState(null)
-
+const AddForm = ({onClose, errorMessage, validationMessage, onAdd}) => {
   const [nom, setNom] = useState('')
   const [email, setEmail] = useState('')
 
-  const onAdd = async e => {
-    e.preventDefault()
-
-    setErrorMessage(null)
-    setValidationMessage(null)
-
-    try {
-      await addCreator(token, {nom, email})
-      setValidationMessage(`${nom} a été ajouté à la liste des porteurs autorisés`)
-
-      setTimeout(() => {
-        handleReloadData()
-        handleFormOpen()
-      }, 1000)
-    } catch (error) {
-      setErrorMessage('Le nouveau porteur n’a pas pu être ajouté : ' + error)
-    }
-  }
-
   return (
-    <form className='fr-grid-row fr-my-6w fr-pb-4w' onSubmit={onAdd}>
+    <form className='fr-grid-row fr-my-6w fr-pb-4w' onSubmit={e => onAdd(e, nom, email)}>
       <div className='fr-grid-row fr-grid-row--gutters fr-col-12 '>
         <div className='fr-col-12 fr-col-md-4'>
           <TextInput
@@ -95,10 +71,15 @@ const AddForm = ({token, onClose, handleReloadData, handleFormOpen}) => {
 }
 
 AddForm.propTypes = {
-  token: PropTypes.string.isRequired,
-  handleReloadData: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string,
+  validationMessage: PropTypes.string,
   onClose: PropTypes.func.isRequired,
-  handleFormOpen: PropTypes.func.isRequired
+  onAdd: PropTypes.func.isRequired
+}
+
+AddForm.defaultProps = {
+  errorMessage: null,
+  validationMessage: null
 }
 
 export default AddForm

--- a/components/gestion-admin/add-form.js
+++ b/components/gestion-admin/add-form.js
@@ -6,12 +6,18 @@ import colors from '@/styles/colors.js'
 import TextInput from '@/components/text-input.js'
 import Button from '@/components/button.js'
 
-const AddForm = ({onClose, errorMessage, validationMessage, onAdd}) => {
+const AddForm = ({onClose, errorMessage, validationMessage, onSubmit}) => {
   const [nom, setNom] = useState('')
   const [email, setEmail] = useState('')
 
+  const handleSubmit = event => {
+    event.preventDefault()
+
+    onSubmit(nom, email)
+  }
+
   return (
-    <form className='fr-grid-row fr-my-6w fr-pb-4w' onSubmit={e => onAdd(e, nom, email)}>
+    <form className='fr-grid-row fr-my-6w fr-pb-4w' onSubmit={handleSubmit}>
       <div className='fr-grid-row fr-grid-row--gutters fr-col-12 '>
         <div className='fr-col-12 fr-col-md-4'>
           <TextInput
@@ -74,7 +80,7 @@ AddForm.propTypes = {
   errorMessage: PropTypes.string,
   validationMessage: PropTypes.string,
   onClose: PropTypes.func.isRequired,
-  onAdd: PropTypes.func.isRequired
+  onSubmit: PropTypes.func.isRequired
 }
 
 AddForm.defaultProps = {

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -73,7 +73,7 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
           errorMessage={errorMessage}
           validationMessage={validationMessage}
           handleReloadData={handleReloadData}
-          onAdd={onAdd}
+          onSubmit={onAdd}
           onClose={handleFormOpen}
         />
       )}

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -14,7 +14,7 @@ const orderOptions = [
   {value: 'desc', label: 'Date d’ajout décroissante'}
 ]
 
-const Header = ({token, items, isAdmin, handleFilteredItems, handleReloadData}) => {
+const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, handleFilteredItems, handleReloadData}) => {
   const [orderValue, setOrderValue] = useState('alpha')
   const [searchValue, setSearchValue] = useState('')
   const [isFormOpen, setIsFormOpen] = useState(false)
@@ -29,6 +29,14 @@ const Header = ({token, items, isAdmin, handleFilteredItems, handleReloadData}) 
       handleFilteredItems(items)
     }
   }, [items, searchValue, handleFilteredItems])
+
+  useEffect(() => {
+    if (validationMessage) {
+      setTimeout(() => {
+        setIsFormOpen(false)
+      }, 1000)
+    }
+  }, [validationMessage])
 
   useEffect(() => {
     if (orderValue === 'alpha') {
@@ -61,8 +69,11 @@ const Header = ({token, items, isAdmin, handleFilteredItems, handleReloadData}) 
       {isFormOpen && (
         <AddForm
           token={token}
-          handleReloadData={handleReloadData}
           handleFormOpen={() => setIsFormOpen(!isFormOpen)}
+          errorMessage={errorMessage}
+          validationMessage={validationMessage}
+          handleReloadData={handleReloadData}
+          onAdd={onAdd}
           onClose={handleFormOpen}
         />
       )}
@@ -98,13 +109,18 @@ const Header = ({token, items, isAdmin, handleFilteredItems, handleReloadData}) 
 
 Header.propTypes = {
   token: PropTypes.string.isRequired,
+  errorMessage: PropTypes.string,
+  validationMessage: PropTypes.string,
   items: PropTypes.array.isRequired,
   isAdmin: PropTypes.bool,
-  handleReloadData: PropTypes.func.isRequired,
-  handleFilteredItems: PropTypes.func.isRequired
+  onAdd: PropTypes.func.isRequired,
+  handleFilteredItems: PropTypes.func.isRequired,
+  handleReloadData: PropTypes.func.isRequired
 }
 
 Header.defaultProps = {
+  errorMessage: null,
+  validationMessage: null,
   isAdmin: false
 }
 

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -14,8 +14,8 @@ const Porteurs = () => {
   const {token, isTokenRecovering} = useContext(AuthentificationContext)
 
   const [errorMessage, setErrorMessage] = useState(null)
-  const [onAddError, setOnAddError] = useState(null)
-  const [onAddValidation, setOnAddValidation] = useState(null)
+  const [addError, setAddError] = useState(null)
+  const [addValidation, setAddValidation] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [porteurs, setPorteurs] = useState([])
   const [filteredPorteurs, setFilteredPorteurs] = useState([])
@@ -35,18 +35,18 @@ const Porteurs = () => {
   const onAddCreators = async (e, nom, email) => {
     e.preventDefault()
 
-    setOnAddValidation(null)
-    setOnAddError(null)
+    setAddValidation(null)
+    setAddError(null)
 
     try {
       await addCreator(token, {nom, email})
-      setOnAddValidation(`${nom} a été ajouté à la liste des porteurs autorisés`)
+      setAddValidation(`${nom} a été ajouté à la liste des porteurs autorisés`)
 
       setTimeout(() => {
         getPorteurs()
       }, 1000)
     } catch (error) {
-      setOnAddError(null)('Le nouveau porteur n’a pas pu être ajouté : ' + error)
+      setAddError(null)('Le nouveau porteur n’a pas pu être ajouté : ' + error)
     }
   }
 
@@ -65,8 +65,8 @@ const Porteurs = () => {
         items={porteurs}
         handleFilteredItems={setFilteredPorteurs}
         handleReloadData={getPorteurs}
-        errorMessage={onAddError}
-        validationMessage={onAddValidation}
+        errorMessage={addError}
+        validationMessage={addValidation}
         onAdd={onAddCreators}
       />
 

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -13,38 +13,39 @@ import AuthentificationContext from '@/contexts/authentification-token.js'
 const Porteurs = () => {
   const {token, isTokenRecovering} = useContext(AuthentificationContext)
 
-  const [errorMessage, setErrorMessage] = useState(null)
-  const [addError, setAddError] = useState(null)
-  const [addValidation, setAddValidation] = useState(null)
+  const [errorMessages, setErrorMessages] = useState({headerError: null, fetchError: null})
+  const [validationMessage, setValidationMessage] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [porteurs, setPorteurs] = useState([])
   const [filteredPorteurs, setFilteredPorteurs] = useState([])
 
   const getPorteurs = useCallback(async () => {
+    setErrorMessages(errorMessages => ({...errorMessages, fetchError: null}))
+
     try {
       const getPorteurs = await getCreators(token)
 
       setPorteurs(orderBy(getPorteurs, [item => normalizeSort(item.nom || 'N/A')], ['asc']))
     } catch {
-      setErrorMessage('La liste des porteurs de projets n’a pas pu être récupérée')
+      setErrorMessages(errorMessages => ({...errorMessages, fetchError: 'La liste des porteurs de projets n’a pas pu être récupérée'}))
     }
 
     setIsLoading(false)
   }, [token])
 
   const onAddCreators = async (nom, email) => {
-    setAddValidation(null)
-    setAddError(null)
+    setValidationMessage(null)
+    setErrorMessages(errorMessages => ({...errorMessages, headerError: null}))
 
     try {
       await addCreator(token, {nom, email})
-      setAddValidation(`${nom} a été ajouté à la liste des porteurs autorisés`)
+      setValidationMessage(`${nom} a été ajouté à la liste des porteurs autorisés`)
 
       setTimeout(() => {
         getPorteurs()
       }, 1000)
-    } catch (error) {
-      setAddError('Le nouveau porteur n’a pas pu être ajouté : ' + error)
+    } catch {
+      setErrorMessages(errorMessages => ({...errorMessages, headerError: 'Le nouveau porteur n’a pas pu être ajouté : '}))
     }
   }
 
@@ -63,8 +64,8 @@ const Porteurs = () => {
         items={porteurs}
         handleFilteredItems={setFilteredPorteurs}
         handleReloadData={getPorteurs}
-        errorMessage={addError}
-        validationMessage={addValidation}
+        errorMessage={errorMessages.headerError}
+        validationMessage={validationMessage}
         onAdd={onAddCreators}
       />
 
@@ -78,7 +79,7 @@ const Porteurs = () => {
         <p className='fr-mt-4w'> <i>La liste des porteurs de projets autorisés est vide.</i></p>
       )}
 
-      {errorMessage && <p className='fr-error-text'>{errorMessage}</p>}
+      {errorMessages.fetchError && <p className='fr-error-text'>{errorMessages.fetchError}</p>}
     </div>
   )
 }

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -1,7 +1,7 @@
 import {useState, useEffect, useCallback, useContext} from 'react'
 import {orderBy} from 'lodash'
 
-import {getCreators} from '@/lib/suivi-pcrs.js'
+import {getCreators, addCreator} from '@/lib/suivi-pcrs.js'
 import {normalizeSort} from '@/lib/string.js'
 
 import PorteurList from '@/components/gestion-admin/porteur-list.js'
@@ -14,6 +14,8 @@ const Porteurs = () => {
   const {token, isTokenRecovering} = useContext(AuthentificationContext)
 
   const [errorMessage, setErrorMessage] = useState(null)
+  const [onAddError, setOnAddError] = useState(null)
+  const [onAddValidation, setOnAddValidation] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [porteurs, setPorteurs] = useState([])
   const [filteredPorteurs, setFilteredPorteurs] = useState([])
@@ -30,6 +32,24 @@ const Porteurs = () => {
     setIsLoading(false)
   }, [token])
 
+  const onAddCreators = async (e, nom, email) => {
+    e.preventDefault()
+
+    setOnAddValidation(null)
+    setOnAddError(null)
+
+    try {
+      await addCreator(token, {nom, email})
+      setOnAddValidation(`${nom} a été ajouté à la liste des porteurs autorisés`)
+
+      setTimeout(() => {
+        getPorteurs()
+      }, 1000)
+    } catch (error) {
+      setOnAddError(null)('Le nouveau porteur n’a pas pu être ajouté : ' + error)
+    }
+  }
+
   useEffect(() => {
     if (token && !isTokenRecovering) {
       getPorteurs()
@@ -45,6 +65,9 @@ const Porteurs = () => {
         items={porteurs}
         handleFilteredItems={setFilteredPorteurs}
         handleReloadData={getPorteurs}
+        errorMessage={onAddError}
+        validationMessage={onAddValidation}
+        onAdd={onAddCreators}
       />
 
       {filteredPorteurs.length > 0 ? (

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -32,9 +32,7 @@ const Porteurs = () => {
     setIsLoading(false)
   }, [token])
 
-  const onAddCreators = async (e, nom, email) => {
-    e.preventDefault()
-
+  const onAddCreators = async (nom, email) => {
     setAddValidation(null)
     setAddError(null)
 

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -44,7 +44,7 @@ const Porteurs = () => {
         getPorteurs()
       }, 1000)
     } catch (error) {
-      setAddError(null)('Le nouveau porteur n’a pas pu être ajouté : ' + error)
+      setAddError('Le nouveau porteur n’a pas pu être ajouté : ' + error)
     }
   }
 


### PR DESCRIPTION
La fonction permettant d'ajouter un porteur dans la base de données se trouvait dans le composant `/gestion-admin/header.js` qui sera partagé avec la gestion des administrateurs.
Cette fonction est à présent passée en prop (`onAdd`) dans `<Header />`