### PR TITLE
Ajout de la gestion des administrateurs 

### DIFF
--- a/components/gestion-admin/add-form.js
+++ b/components/gestion-admin/add-form.js
@@ -79,12 +79,14 @@ const AddForm = ({onClose, errorMessage, validationMessage, isAdmin, onSubmit}) 
 AddForm.propTypes = {
   errorMessage: PropTypes.string,
   validationMessage: PropTypes.string,
+  isAdmin: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired
 }
 
 AddForm.defaultProps = {
   errorMessage: null,
+  isAdmin: false,
   validationMessage: null
 }
 

--- a/components/gestion-admin/add-form.js
+++ b/components/gestion-admin/add-form.js
@@ -6,7 +6,7 @@ import colors from '@/styles/colors.js'
 import TextInput from '@/components/text-input.js'
 import Button from '@/components/button.js'
 
-const AddForm = ({onClose, errorMessage, validationMessage, onSubmit}) => {
+const AddForm = ({onClose, errorMessage, validationMessage, isAdmin, onSubmit}) => {
   const [nom, setNom] = useState('')
   const [email, setEmail] = useState('')
 
@@ -23,10 +23,10 @@ const AddForm = ({onClose, errorMessage, validationMessage, onSubmit}) => {
           <TextInput
             isRequired
             autoFocus
-            label='Nom du porteur'
-            ariaLabel='nom du porteur'
+            label={`Nom ${isAdmin ? 'de l’administrateur' : 'du porteur'}`}
+            ariaLabel={`Nom ${isAdmin ? 'de l’administrateur' : 'du porteur'}`}
             value={nom}
-            placeholder='Nom du porteur'
+            placeholder={`Nom ${isAdmin ? 'de l’administrateur' : 'du porteur'}`}
             onValueChange={e => setNom(e.target.value)}
           />
         </div>
@@ -34,10 +34,10 @@ const AddForm = ({onClose, errorMessage, validationMessage, onSubmit}) => {
           <TextInput
             isRequired
             type='email'
-            label='Email du porteur'
-            ariaLabel='email du porteur'
+            label={`Email ${isAdmin ? 'de l’administrateur' : 'du porteur'}`}
+            ariaLabel={`Email ${isAdmin ? 'de l’administrateur' : 'du porteur'}`}
             value={email}
-            placeholder='Email du porteur'
+            placeholder={`Email ${isAdmin ? 'de l’administrateur' : 'du porteur'}`}
             onValueChange={e => setEmail(e.target.value)}
           />
         </div>
@@ -48,7 +48,7 @@ const AddForm = ({onClose, errorMessage, validationMessage, onSubmit}) => {
 
           <div className='fr-pr-3w'>
             <Button
-              label='Annuler l’ajout du livrable'
+              label={`Annuler l’ajout ${isAdmin ? 'de l’administrateur' : 'du porteur'}`}
               buttonStyle='tertiary'
               onClick={onClose}
             >
@@ -57,7 +57,7 @@ const AddForm = ({onClose, errorMessage, validationMessage, onSubmit}) => {
           </div>
           <Button
             type='submit'
-            label='Valider l’ajout du porteur'
+            label={`Valider l’ajout ${isAdmin ? 'de l’administrateur' : 'du porteur'}`}
             icon='checkbox-circle-fill'
           >
             Valider

--- a/components/gestion-admin/administrateur-list.js
+++ b/components/gestion-admin/administrateur-list.js
@@ -45,7 +45,6 @@ const AdministrateurList = ({loggedUserToken, administrateurs, handleReloadAdmin
               email={email}
               nom={nom}
               creationDate={_created}
-              isAdmin={loggedUserToken === token}
               handleModal={() => handleConfirmationModal(_id)}
             />
           </li>

--- a/components/gestion-admin/administrateur-list.js
+++ b/components/gestion-admin/administrateur-list.js
@@ -24,17 +24,17 @@ const AdministrateurList = ({loggedUserToken, administrateurs, handleReloadAdmin
   const onRevoke = async (_id, nom, token) => {
     setErrorMessage(null)
 
-    try {
-      await deleteAdministrator(_id, loggedUserToken)
-      setValidationMessage(`Les droits administrateurs de ${nom} ont été révoqués`)
+    if (token === loggedUserToken) {
+      setErrorMessage('Il est impossible de révoquer ses propres droits administrateurs')
+    } else {
+      try {
+        await deleteAdministrator(_id, loggedUserToken)
+        setValidationMessage(`Les droits administrateurs de ${nom} ont été révoqués`)
 
-      setTimeout(() => {
-        handleReloadAdmins()
-      }, 2000)
-    } catch {
-      if (token === loggedUserToken) {
-        setErrorMessage('Il est impossible de révoquer ses propres droits administrateurs')
-      } else {
+        setTimeout(() => {
+          handleReloadAdmins()
+        }, 2000)
+      } catch {
         setErrorMessage(`Les droits administrateurs de ${nom} n’ont pas pu être révoqués`)
       }
     }

--- a/components/gestion-admin/administrateur-list.js
+++ b/components/gestion-admin/administrateur-list.js
@@ -1,0 +1,101 @@
+import {useState} from 'react'
+import PropTypes from 'prop-types'
+
+import {deleteAdministrator} from '@/lib/suivi-pcrs.js'
+
+import ListItem from '@/components/gestion-admin/list-item.js'
+import Modal from '@/components/modal.js'
+
+const AdministrateurList = ({loggedUserToken, administrateurs, handleReloadAdmins}) => {
+  const [errorMessage, setErrorMessage] = useState(null)
+  const [validationMessage, setValidationMessage] = useState(null)
+  const [selectedAdminId, setSelectedAdminId] = useState(null)
+
+  const handleConfirmationModal = id => {
+    setErrorMessage(null)
+    setValidationMessage(null)
+    if (selectedAdminId) {
+      setSelectedAdminId(null)
+    } else {
+      setSelectedAdminId(id)
+    }
+  }
+
+  const onRevoke = async (_id, nom, token) => {
+    setErrorMessage(null)
+
+    try {
+      await deleteAdministrator(_id, loggedUserToken)
+      setValidationMessage(`Les droits administrateurs de ${nom} ont été révoqués`)
+
+      setTimeout(() => {
+        handleReloadAdmins()
+      }, 2000)
+    } catch {
+      if (token === loggedUserToken) {
+        setErrorMessage('Il est impossible de révoquer ses propres droits administrateurs')
+      } else {
+        setErrorMessage(`Les droits administrateurs de ${nom} n’ont pas pu être révoqués`)
+      }
+    }
+  }
+
+  return (
+    <ul className='fr-mt-2w fr-p-0'>
+      {administrateurs.map(({_id, email, nom, _created, token}) => (
+        <div key={_id}>
+          <li className='fr-my-2w'>
+            <ListItem
+              email={email}
+              nom={nom}
+              creationDate={_created}
+              isAdmin={loggedUserToken === token}
+              handleModal={() => handleConfirmationModal(_id)}
+            />
+          </li>
+
+          {selectedAdminId === _id && (
+            <Modal title='Êtes-vous sûr de révoquer les droits de cet administrateur ?' onClose={handleConfirmationModal}>
+              <div className='fr-grid-row fr-grid-row--center'>
+                <div className='fr-alert fr-col-12 fr-alert--warning fr-alert--sm fr-my-5w'>
+                  <p><b>{nom}</b> perdra ses droits administrateur et ne sera plus en mesure de créer <b>des projets</b> ou bien gérer <b>les porteurs</b> et <b>les administrateurs</b>. Si vous souhaitez <b>restaurer ses droits</b>, vous devrez de nouveau l’ajouter à la liste des <b>administrateurs autorisés</b>.</p>
+                </div>
+
+                <div className='fr-grid-row fr-grid-row--center'>
+                  <button
+                    disabled={Boolean(validationMessage)}
+                    type='button'
+                    aria-label='Révoquer le porteur'
+                    className='fr-btn revoke-button fr-py-1w fr-px-1w'
+                    onClick={() => onRevoke(_id, nom, token)}
+                  >
+                    <span className='fr-icon-close-circle-line fr-pr-1w' aria-hidden='true' />Révoquer {nom}
+                  </button>
+                  {validationMessage && (
+                    <p className='fr-grid-row fr-grid-row--center fr-valid-text fr-col-12 fr-mt-2w fr-mb-0'>
+                      {validationMessage}
+                    </p>
+                  )}
+
+                  {errorMessage && (
+                    <p className='fr-grid-row fr-grid-row--center fr-error-text fr-col-12 fr-mt-2w fr-mb-0'>
+                      {errorMessage}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </Modal>
+          )}
+        </div>
+      ))}
+    </ul>
+  )
+}
+
+AdministrateurList.propTypes = {
+  loggedUserToken: PropTypes.string.isRequired,
+  administrateurs: PropTypes.array.isRequired,
+  handleReloadAdmins: PropTypes.func.isRequired
+}
+
+export default AdministrateurList

--- a/components/gestion-admin/administrateur-list.js
+++ b/components/gestion-admin/administrateur-list.js
@@ -21,22 +21,18 @@ const AdministrateurList = ({loggedUserToken, administrateurs, handleReloadAdmin
     }
   }
 
-  const onRevoke = async (_id, nom, token) => {
+  const onRevoke = async (_id, nom) => {
     setErrorMessage(null)
 
-    if (token === loggedUserToken) {
-      setErrorMessage('Il est impossible de révoquer ses propres droits administrateurs')
-    } else {
-      try {
-        await deleteAdministrator(_id, loggedUserToken)
-        setValidationMessage(`Les droits administrateurs de ${nom} ont été révoqués`)
+    try {
+      await deleteAdministrator(_id, loggedUserToken)
+      setValidationMessage(`Les droits administrateurs de ${nom} ont été révoqués`)
 
-        setTimeout(() => {
-          handleReloadAdmins()
-        }, 2000)
-      } catch {
-        setErrorMessage(`Les droits administrateurs de ${nom} n’ont pas pu être révoqués`)
-      }
+      setTimeout(() => {
+        handleReloadAdmins()
+      }, 2000)
+    } catch (error) {
+      setErrorMessage(error.message)
     }
   }
 

--- a/components/gestion-admin/administrateurs.js
+++ b/components/gestion-admin/administrateurs.js
@@ -69,7 +69,6 @@ const Administrateurs = () => {
         token={token}
         items={admins}
         handleFilteredItems={setFilteredAdmins}
-        handleReloadData={getAdministrators}
         errorMessage={errors.headerError}
         validationMessage={validationMessage}
         onReset={() => clearError('headerError')}

--- a/components/gestion-admin/administrateurs.js
+++ b/components/gestion-admin/administrateurs.js
@@ -6,6 +6,8 @@ import {normalizeSort} from '@/lib/string.js'
 
 import AuthentificationContext from '@/contexts/authentification-token.js'
 
+import useErrors from '@/hooks/errors.js'
+
 import AdministrateurList from '@/components/gestion-admin/administrateur-list.js'
 import Header from '@/components/gestion-admin/header.js'
 import Loader from '@/components/loader.js'
@@ -17,26 +19,26 @@ const Administrateurs = () => {
   const [filteredAdmins, setFilteredAdmins] = useState([])
   const [isLoading, setIsLoading] = useState(false)
   const [validationMessage, setValidationMessage] = useState(null)
-  const [errorMessages, setErrorMessages] = useState({headerError: null, fetchError: null})
+  const [errors, setError, clearError] = useErrors({fetchError: null, headerError: null})
 
   const getAdmins = useCallback(async () => {
     setIsLoading(true)
-    setErrorMessages(errorMessages => ({...errorMessages, fetchError: null}))
+    clearError('fetchError')
 
     try {
       const administrators = await getAdministrators(token)
 
       setAdmins(orderBy(administrators, [item => normalizeSort(item.nom || 'N/A')], ['asc']))
     } catch {
-      setErrorMessages(errorMessages => ({...errorMessages, fetchError: 'Une erreur a été rencontrée lors de la récupération des administrateurs'}))
+      setError('fetchError', 'Une erreur a été rencontrée lors de la récupération des administrateurs')
     }
 
     setIsLoading(false)
-  }, [token])
+  }, [token, setError, clearError])
 
   const onAddAdmin = async (nom, email) => {
     setValidationMessage(null)
-    setErrorMessages(errorMessages => ({...errorMessages, headerError: null}))
+    clearError('headerError')
 
     try {
       await addAdministator(token, {nom, email})
@@ -47,7 +49,7 @@ const Administrateurs = () => {
         setValidationMessage(null)
       }, 1000)
     } catch {
-      setErrorMessages(errorMessages => ({...errorMessages, headerError: 'Le nouvel administrateur n’a pas pu être ajouté'}))
+      setError('headerError', 'Le nouvel administrateur n’a pas pu être ajouté')
     }
   }
 
@@ -67,8 +69,9 @@ const Administrateurs = () => {
         items={admins}
         handleFilteredItems={setFilteredAdmins}
         handleReloadData={getAdministrators}
-        errorMessage={errorMessages.headerError}
+        errorMessage={errors.headerError}
         validationMessage={validationMessage}
+        onReset={() => clearError('fetchError')}
         onAdd={onAddAdmin}
       />
 
@@ -82,7 +85,7 @@ const Administrateurs = () => {
         <p className='fr-mt-4w'> <i>La liste des administrateurs est vide.</i></p>
       )}
 
-      {errorMessages.fetchError && <p className='fr-error-text'>{errorMessages.fetchError}</p>}
+      {errors.fetchError && <p className='fr-error-text'>{errors.fetchError}</p>}
     </div>
   )
 }

--- a/components/gestion-admin/administrateurs.js
+++ b/components/gestion-admin/administrateurs.js
@@ -1,0 +1,89 @@
+import {useState, useEffect, useCallback, useContext} from 'react'
+import {orderBy} from 'lodash'
+
+import {getAdministrators, addAdministator} from '@/lib/suivi-pcrs.js'
+
+import AuthentificationContext from '@/contexts/authentification-token.js'
+
+import AdministrateurList from '@/components/gestion-admin/administrateur-list.js'
+import Header from '@/components/gestion-admin/header.js'
+import Loader from '@/components/loader.js'
+
+const Administrateurs = () => {
+  const {token, isTokenRecovering} = useContext(AuthentificationContext)
+
+  const [admins, setAdmins] = useState([])
+  const [filteredAdmins, setFilteredAdmins] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [validationMessage, setValidationMessage] = useState(null)
+  const [errorMessages, setErrorMessages] = useState({headerError: null, fetchError: null})
+
+  const getAdmins = useCallback(async () => {
+    setIsLoading(true)
+    setErrorMessages(errorMessages => ({...errorMessages, fetchError: null}))
+
+    try {
+      const administrators = await getAdministrators(token)
+
+      setAdmins(orderBy(administrators, [item => item.nom ? item.nom.toLowerCase() : 'N/A'.toLowerCase()], ['asc']))
+    } catch {
+      setErrorMessages(errorMessages => ({...errorMessages, fetchError: 'Une erreur a été rencontrée lors de la récupération des administrateurs'}))
+    }
+
+    setIsLoading(false)
+  }, [token])
+
+  const onAddAdmin = async (nom, email) => {
+    setValidationMessage(null)
+    setErrorMessages(errorMessages => ({...errorMessages, headerError: null}))
+
+    try {
+      await addAdministator(token, {nom, email})
+      setValidationMessage(`${nom} a été ajouté à la liste des administrateurs`)
+
+      setTimeout(() => {
+        getAdmins()
+        setValidationMessage(null)
+      }, 1000)
+    } catch {
+      setErrorMessages(errorMessages => ({...errorMessages, headerError: 'Le nouvel administrateur n’a pas pu être ajouté'}))
+    }
+  }
+
+  useEffect(() => {
+    if (token && !isTokenRecovering) {
+      getAdmins()
+    }
+  }, [token, isTokenRecovering, getAdmins])
+
+  return isLoading ? (
+    <div className='fr-grid-row fr-col-12 fr-grid-row--center fr-my-3w'><Loader /></div>
+  ) : (
+    <div>
+      <Header
+        isAdmin
+        token={token}
+        items={admins}
+        handleFilteredItems={setFilteredAdmins}
+        handleReloadData={getAdministrators}
+        errorMessage={errorMessages.headerError}
+        validationMessage={validationMessage}
+        onAdd={onAddAdmin}
+      />
+
+      {filteredAdmins.length > 0 ? (
+        <AdministrateurList
+          loggedUserToken={token}
+          administrateurs={filteredAdmins}
+          handleReloadAdmins={getAdmins}
+        />
+      ) : (
+        <p className='fr-mt-4w'> <i>La liste des administrateurs est vide.</i></p>
+      )}
+
+      {errorMessages.fetchError && <p className='fr-error-text'>{errorMessages.fetchError}</p>}
+    </div>
+  )
+}
+
+export default Administrateurs

--- a/components/gestion-admin/administrateurs.js
+++ b/components/gestion-admin/administrateurs.js
@@ -15,7 +15,7 @@ import Loader from '@/components/loader.js'
 const Administrateurs = () => {
   const {token, isTokenRecovering} = useContext(AuthentificationContext)
 
-  const [admins, setAdmins] = useState([])
+  const [admins, setAdmins] = useState()
   const [filteredAdmins, setFilteredAdmins] = useState([])
   const [isLoading, setIsLoading] = useState(false)
   const [validationMessage, setValidationMessage] = useState(null)
@@ -24,6 +24,7 @@ const Administrateurs = () => {
   const getAdmins = useCallback(async () => {
     setIsLoading(true)
     clearError('fetchError')
+    setIsLoading(true)
 
     try {
       const administrators = await getAdministrators(token)

--- a/components/gestion-admin/administrateurs.js
+++ b/components/gestion-admin/administrateurs.js
@@ -30,8 +30,8 @@ const Administrateurs = () => {
       const administrators = await getAdministrators(token)
 
       setAdmins(orderBy(administrators, [item => normalizeSort(item.nom || 'N/A')], ['asc']))
-    } catch {
-      setError('fetchError', 'Une erreur a été rencontrée lors de la récupération des administrateurs')
+    } catch (error) {
+      setError('fetchError', error.message)
     }
 
     setIsLoading(false)
@@ -49,8 +49,8 @@ const Administrateurs = () => {
         getAdmins()
         setValidationMessage(null)
       }, 1000)
-    } catch {
-      setError('headerError', 'Le nouvel administrateur n’a pas pu être ajouté')
+    } catch (error) {
+      setError('headerError', error.message)
     }
   }
 
@@ -72,7 +72,7 @@ const Administrateurs = () => {
         handleReloadData={getAdministrators}
         errorMessage={errors.headerError}
         validationMessage={validationMessage}
-        onReset={() => clearError('fetchError')}
+        onReset={() => clearError('headerError')}
         onAdd={onAddAdmin}
       />
 
@@ -82,7 +82,7 @@ const Administrateurs = () => {
           administrateurs={filteredAdmins}
           handleReloadAdmins={getAdmins}
         />
-      ) : (
+      ) : !errors.fetchError && (
         <p className='fr-mt-4w'> <i>La liste des administrateurs est vide.</i></p>
       )}
 

--- a/components/gestion-admin/administrateurs.js
+++ b/components/gestion-admin/administrateurs.js
@@ -2,6 +2,7 @@ import {useState, useEffect, useCallback, useContext} from 'react'
 import {orderBy} from 'lodash'
 
 import {getAdministrators, addAdministator} from '@/lib/suivi-pcrs.js'
+import {normalizeSort} from '@/lib/string.js'
 
 import AuthentificationContext from '@/contexts/authentification-token.js'
 
@@ -25,7 +26,7 @@ const Administrateurs = () => {
     try {
       const administrators = await getAdministrators(token)
 
-      setAdmins(orderBy(administrators, [item => item.nom ? item.nom.toLowerCase() : 'N/A'.toLowerCase()], ['asc']))
+      setAdmins(orderBy(administrators, [item => normalizeSort(item.nom || 'N/A')], ['asc']))
     } catch {
       setErrorMessages(errorMessages => ({...errorMessages, fetchError: 'Une erreur a été rencontrée lors de la récupération des administrateurs'}))
     }

--- a/components/gestion-admin/administrateurs.js
+++ b/components/gestion-admin/administrateurs.js
@@ -22,7 +22,6 @@ const Administrateurs = () => {
   const [errors, setError, clearError] = useErrors({fetchError: null, headerError: null})
 
   const getAdmins = useCallback(async () => {
-    setIsLoading(true)
     clearError('fetchError')
     setIsLoading(true)
 

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -23,7 +23,7 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
 
   useEffect(() => {
     if (searchValue) {
-      const filteredResults = items.filter(item => item.email.toLowerCase().includes(searchValue.toLowerCase()) || item?.nom?.toLowerCase()?.includes(searchValue.toLowerCase()))
+      const filteredResults = items.filter(item => normalizeSort(item.email).includes(normalizeSort(searchValue)) || normalizeSort(item.nom || '').includes(normalizeSort(searchValue)))
       handleFilteredItems(filteredResults)
     } else {
       handleFilteredItems(items)

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -114,7 +114,7 @@ Header.propTypes = {
   token: PropTypes.string.isRequired,
   errorMessage: PropTypes.string,
   validationMessage: PropTypes.string,
-  items: PropTypes.array.isRequired,
+  items: PropTypes.array,
   isAdmin: PropTypes.bool,
   onAdd: PropTypes.func.isRequired,
   onReset: PropTypes.func.isRequired,
@@ -123,6 +123,7 @@ Header.propTypes = {
 }
 
 Header.defaultProps = {
+  items: [],
   errorMessage: null,
   validationMessage: null,
   isAdmin: false

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -59,11 +59,11 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
       <Button
         icon='user-add-line'
         iconSide='right'
-        label={`Autoriser un ${isAdmin ? 'nouvel admin' : 'nouveau porteur'}`}
+        label={`Autoriser un ${isAdmin ? 'nouvel administrateur' : 'nouveau porteur'}`}
         isDisabled={isFormOpen}
         onClick={handleFormOpen}
       >
-        Autoriser un {isAdmin ? 'nouvel admin' : 'nouveau porteur'}
+        Autoriser un {isAdmin ? 'nouvel administrateur' : 'nouveau porteur'}
       </Button>
 
       {isFormOpen && (
@@ -81,7 +81,7 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
       <div className='fr-grid-row fr-grid-row--middle fr-mt-8w'>
         <div className='fr-col-12 fr-col-md-4'>
           <label className='fr-label fr-mb-1w'>
-            <b>Rechercher un {isAdmin ? 'admin' : 'porteur'}</b>
+            <b>Rechercher un {isAdmin ? 'administrateur' : 'porteur'}</b>
           </label>
           <div className='fr-search-bar' >
             <input
@@ -96,7 +96,7 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
         <div className='fr-grid-row fr-grid-row--right fr-col-12 fr-col-md-8 fr-mt-6w fr-mt-md-0'>
           <SelectInput
             label='Trier par :'
-            ariaLabel={`Ordonner les ${isAdmin ? 'admin' : 'porteur'} par date d’ajout ou par ordre alphabétique`}
+            ariaLabel={`Ordonner les ${isAdmin ? 'administrateur' : 'porteur'} par date d’ajout ou par ordre alphabétique`}
             value={orderValue}
             options={orderOptions}
             onValueChange={e => setOrderValue(e.target.value)}

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -23,7 +23,11 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
 
   useEffect(() => {
     if (searchValue) {
-      const filteredResults = items.filter(item => normalizeSort(item.email).includes(normalizeSort(searchValue)) || normalizeSort(item.nom || '').includes(normalizeSort(searchValue)))
+      // Filter items based on whether email or name contains search value. Those elements are converted to lowercase and diacritics are removed.
+      const filteredResults = items.filter(item =>
+        normalizeSort(item.email).includes(normalizeSort(searchValue)) || normalizeSort(item.nom || '').includes(normalizeSort(searchValue))
+      )
+
       handleFilteredItems(filteredResults)
     } else {
       handleFilteredItems(items)

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -75,6 +75,7 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
           handleFormOpen={() => setIsFormOpen(!isFormOpen)}
           errorMessage={errorMessage}
           validationMessage={validationMessage}
+          isAdmin={isAdmin}
           handleReloadData={handleReloadData}
           onSubmit={onAdd}
           onClose={() => {

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -14,7 +14,7 @@ const orderOptions = [
   {value: 'desc', label: 'Date d’ajout décroissante'}
 ]
 
-const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, handleFilteredItems, handleReloadData}) => {
+const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, onReset, handleFilteredItems, handleReloadData}) => {
   const [orderValue, setOrderValue] = useState('alpha')
   const [searchValue, setSearchValue] = useState('')
   const [isFormOpen, setIsFormOpen] = useState(false)
@@ -61,7 +61,10 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
         iconSide='right'
         label={`Autoriser un ${isAdmin ? 'nouvel administrateur' : 'nouveau porteur'}`}
         isDisabled={isFormOpen}
-        onClick={handleFormOpen}
+        onClick={() => {
+          onReset()
+          handleFormOpen()
+        }}
       >
         Autoriser un {isAdmin ? 'nouvel administrateur' : 'nouveau porteur'}
       </Button>
@@ -114,6 +117,7 @@ Header.propTypes = {
   items: PropTypes.array.isRequired,
   isAdmin: PropTypes.bool,
   onAdd: PropTypes.func.isRequired,
+  onReset: PropTypes.func.isRequired,
   handleFilteredItems: PropTypes.func.isRequired,
   handleReloadData: PropTypes.func.isRequired
 }

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -77,7 +77,10 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
           validationMessage={validationMessage}
           handleReloadData={handleReloadData}
           onSubmit={onAdd}
-          onClose={handleFormOpen}
+          onClose={() => {
+            onReset()
+            handleFormOpen()
+          }}
         />
       )}
 

--- a/components/gestion-admin/header.js
+++ b/components/gestion-admin/header.js
@@ -14,7 +14,7 @@ const orderOptions = [
   {value: 'desc', label: 'Date d’ajout décroissante'}
 ]
 
-const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, onReset, handleFilteredItems, handleReloadData}) => {
+const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, onReset, handleFilteredItems}) => {
   const [orderValue, setOrderValue] = useState('alpha')
   const [searchValue, setSearchValue] = useState('')
   const [isFormOpen, setIsFormOpen] = useState(false)
@@ -76,7 +76,6 @@ const Header = ({token, items, isAdmin, errorMessage, validationMessage, onAdd, 
           errorMessage={errorMessage}
           validationMessage={validationMessage}
           isAdmin={isAdmin}
-          handleReloadData={handleReloadData}
           onSubmit={onAdd}
           onClose={() => {
             onReset()
@@ -122,8 +121,7 @@ Header.propTypes = {
   isAdmin: PropTypes.bool,
   onAdd: PropTypes.func.isRequired,
   onReset: PropTypes.func.isRequired,
-  handleFilteredItems: PropTypes.func.isRequired,
-  handleReloadData: PropTypes.func.isRequired
+  handleFilteredItems: PropTypes.func.isRequired
 }
 
 Header.defaultProps = {

--- a/components/gestion-admin/list-item.js
+++ b/components/gestion-admin/list-item.js
@@ -4,12 +4,12 @@ import colors from '@/styles/colors.js'
 
 import {shortDate} from '@/lib/date-utils.js'
 
-const ListItem = ({email, nom, creationDate, isAdmin, handleModal}) => (
+const ListItem = ({email, nom, creationDate, handleModal}) => (
   <div className='fr-grid-row fr-grid-row--middle fr-p-2w card-container'>
     <div className='fr-col-12 fr-col-md-1'>
       <span
-        className={isAdmin ? 'fr-icon-user-star-fill' : 'fr-icon-user-fill'}
-        style={{color: `${isAdmin ? colors.info425 : colors.darkgrey}`}}
+        className='fr-icon-user-fill'
+        style={{color: colors.darkgrey}}
         aria-hidden='true'
       />
     </div>
@@ -89,12 +89,7 @@ ListItem.propTypes = {
   email: PropTypes.string.isRequired,
   nom: PropTypes.string,
   creationDate: PropTypes.string.isRequired,
-  isAdmin: PropTypes.bool,
   handleModal: PropTypes.func.isRequired
-}
-
-ListItem.defaultProps = {
-  isAdmin: false
 }
 
 export default ListItem

--- a/components/gestion-admin/list-item.js
+++ b/components/gestion-admin/list-item.js
@@ -4,10 +4,14 @@ import colors from '@/styles/colors.js'
 
 import {shortDate} from '@/lib/date-utils.js'
 
-const ListItem = ({email, nom, creationDate, handleModal}) => (
+const ListItem = ({email, nom, creationDate, isAdmin, handleModal}) => (
   <div className='fr-grid-row fr-grid-row--middle fr-p-2w card-container'>
     <div className='fr-col-12 fr-col-md-1'>
-      <span className='fr-icon-user-fill' style={{color: `${colors.blueFranceSun113}`}} aria-hidden='true' />
+      <span
+        className={isAdmin ? 'fr-icon-user-star-fill' : 'fr-icon-user-fill'}
+        style={{color: `${isAdmin ? colors.info425 : colors.darkgrey}`}}
+        aria-hidden='true'
+      />
     </div>
 
     <div className='fr-grid-row fr-grid-row--gutters fr-col-12 fr-col-md-10 fr-mt-2w fr-mt-md-0'>
@@ -85,7 +89,12 @@ ListItem.propTypes = {
   email: PropTypes.string.isRequired,
   nom: PropTypes.string,
   creationDate: PropTypes.string.isRequired,
+  isAdmin: PropTypes.bool,
   handleModal: PropTypes.func.isRequired
+}
+
+ListItem.defaultProps = {
+  isAdmin: false
 }
 
 export default ListItem

--- a/components/gestion-admin/porteur-list.js
+++ b/components/gestion-admin/porteur-list.js
@@ -6,14 +6,14 @@ import {deleteCreator} from '@/lib/suivi-pcrs.js'
 import ListItem from '@/components/gestion-admin/list-item.js'
 import Modal from '@/components/modal.js'
 
-const PorteurList = ({token, porteurs, handleReloadPorteurs}) => {
-  const [errorMessage, setErrorMessage] = useState(null)
+const PorteurList = ({token, porteurs, error, addError, clearError, handleReloadPorteurs}) => {
   const [validationMessage, setValidationMessage] = useState(null)
   const [selectedPorteurId, setSelectedPorteurId] = useState(null)
 
   const handleConfirmationModal = id => {
-    setErrorMessage(null)
+    clearError('revokeError')
     setValidationMessage(null)
+
     if (selectedPorteurId) {
       setSelectedPorteurId(null)
     } else {
@@ -22,7 +22,7 @@ const PorteurList = ({token, porteurs, handleReloadPorteurs}) => {
   }
 
   const onRevoke = async (_id, nom) => {
-    setErrorMessage(null)
+    clearError('revokeError')
 
     try {
       await deleteCreator(_id, token)
@@ -32,7 +32,7 @@ const PorteurList = ({token, porteurs, handleReloadPorteurs}) => {
         handleReloadPorteurs()
       }, 2000)
     } catch {
-      setErrorMessage(`Les droits de création de ${nom} n’ont pas été révoqués`)
+      addError('revokeError', `Les droits de création de ${nom} n’ont pas été révoqués`)
     }
   }
 
@@ -72,9 +72,9 @@ const PorteurList = ({token, porteurs, handleReloadPorteurs}) => {
                     </p>
                   )}
 
-                  {errorMessage && (
+                  {error && (
                     <p className='fr-grid-row fr-grid-row--center fr-error-text fr-col-12 fr-mt-2w fr-mb-0'>
-                      {errorMessage}
+                      {error}
                     </p>
                   )}
                 </div>
@@ -90,7 +90,14 @@ const PorteurList = ({token, porteurs, handleReloadPorteurs}) => {
 PorteurList.propTypes = {
   token: PropTypes.string.isRequired,
   porteurs: PropTypes.array.isRequired,
+  error: PropTypes.string,
+  addError: PropTypes.func.isRequired,
+  clearError: PropTypes.func.isRequired,
   handleReloadPorteurs: PropTypes.func.isRequired
+}
+
+PorteurList.defaultProps = {
+  error: null
 }
 
 export default PorteurList

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -4,6 +4,8 @@ import {orderBy} from 'lodash'
 import {getCreators, addCreator} from '@/lib/suivi-pcrs.js'
 import {normalizeSort} from '@/lib/string.js'
 
+import useErrors from '@/hooks/errors.js'
+
 import PorteurList from '@/components/gestion-admin/porteur-list.js'
 import Header from '@/components/gestion-admin/header.js'
 import Loader from '@/components/loader.js'
@@ -13,29 +15,29 @@ import AuthentificationContext from '@/contexts/authentification-token.js'
 const Porteurs = () => {
   const {token, isTokenRecovering} = useContext(AuthentificationContext)
 
-  const [errorMessages, setErrorMessages] = useState({headerError: null, fetchError: null})
+  const [errors, setError, clearError] = useErrors({fetchError: null, headerError: null})
   const [validationMessage, setValidationMessage] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [porteurs, setPorteurs] = useState([])
   const [filteredPorteurs, setFilteredPorteurs] = useState([])
 
   const getPorteurs = useCallback(async () => {
-    setErrorMessages(errorMessages => ({...errorMessages, fetchError: null}))
+    clearError('fetchError')
 
     try {
       const getPorteurs = await getCreators(token)
 
       setPorteurs(orderBy(getPorteurs, [item => normalizeSort(item.nom || 'N/A')], ['asc']))
     } catch {
-      setErrorMessages(errorMessages => ({...errorMessages, fetchError: 'La liste des porteurs de projets n’a pas pu être récupérée'}))
+      setError('fetchError', 'La liste des porteurs de projets n’a pas pu être récupérée')
     }
 
     setIsLoading(false)
-  }, [token])
+  }, [token, clearError, setError])
 
   const onAddCreators = async (nom, email) => {
     setValidationMessage(null)
-    setErrorMessages(errorMessages => ({...errorMessages, headerError: null}))
+    clearError('headerError')
 
     try {
       await addCreator(token, {nom, email})
@@ -45,7 +47,7 @@ const Porteurs = () => {
         getPorteurs()
       }, 1000)
     } catch {
-      setErrorMessages(errorMessages => ({...errorMessages, headerError: 'Le nouveau porteur n’a pas pu être ajouté : '}))
+      setError('headerError', 'Le nouveau porteur n’a pas pu être ajouté')
     }
   }
 
@@ -64,8 +66,9 @@ const Porteurs = () => {
         items={porteurs}
         handleFilteredItems={setFilteredPorteurs}
         handleReloadData={getPorteurs}
-        errorMessage={errorMessages.headerError}
+        errorMessage={errors.headerError}
         validationMessage={validationMessage}
+        onReset={() => clearError('headerError')}
         onAdd={onAddCreators}
       />
 
@@ -79,7 +82,7 @@ const Porteurs = () => {
         <p className='fr-mt-4w'> <i>La liste des porteurs de projets autorisés est vide.</i></p>
       )}
 
-      {errorMessages.fetchError && <p className='fr-error-text'>{errorMessages.fetchError}</p>}
+      {errors.fetchError && <p className='fr-error-text'>{errors.fetchError}</p>}
     </div>
   )
 }

--- a/components/gestion-admin/porteurs.js
+++ b/components/gestion-admin/porteurs.js
@@ -15,7 +15,7 @@ import AuthentificationContext from '@/contexts/authentification-token.js'
 const Porteurs = () => {
   const {token, isTokenRecovering} = useContext(AuthentificationContext)
 
-  const [errors, setError, clearError] = useErrors({fetchError: null, headerError: null})
+  const [errors, setError, clearError] = useErrors({fetchError: null, headerError: null, revokeError: null})
   const [validationMessage, setValidationMessage] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [porteurs, setPorteurs] = useState([])
@@ -76,7 +76,10 @@ const Porteurs = () => {
         <PorteurList
           token={token}
           porteurs={filteredPorteurs}
+          error={errors.revokeError}
           handleReloadPorteurs={getPorteurs}
+          addError={setError}
+          clearError={clearError}
         />
       ) : (
         <p className='fr-mt-4w'> <i>La liste des porteurs de projets autorisés est vide.</i></p>

--- a/hooks/errors.js
+++ b/hooks/errors.js
@@ -1,0 +1,22 @@
+import {useState, useCallback} from 'react'
+import PropTypes from 'prop-types'
+
+const useErrors = initialState => {
+  const [errors, setErrors] = useState(initialState)
+
+  const setError = useCallback((name, message) => {
+    setErrors(errors => ({...errors, [name]: message}))
+  }, [])
+
+  const clearError = useCallback(name => {
+    setErrors(errors => ({...errors, [name]: ''}))
+  }, [])
+
+  return [errors, setError, clearError]
+}
+
+useErrors.propTypes = {
+  initialState: PropTypes.object.isRequired
+}
+
+export default useErrors

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -181,73 +181,58 @@ export async function deleteCreator(emailId, token) {
 }
 
 export async function getAdministrators(token) {
-  try {
-    const response = await fetch('/administrators', {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Token ${token}`
-      }
-    })
-
-    if (!response.ok) {
-      const {message} = await response.json()
-
-      throw new Error(message)
+  const response = await fetch('/administrators', {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Token ${token}`
     }
+  })
 
-    return response.json()
-  } catch {
-    throw new Error('Une erreur a été rencontrée lors de la récupération des administrateurs.')
+  if (!response.ok) {
+    const {message} = await response.json()
+    throw new Error(message)
   }
+
+  return response.json()
 }
 
 export async function addAdministator(token, administrator) {
-  try {
-    const response = await fetch('/administrators', {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Token ${token}`
-      },
-      body: JSON.stringify(administrator)
-    })
+  const response = await fetch('/administrators', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Token ${token}`
+    },
+    body: JSON.stringify(administrator)
+  })
 
-    if (!response.ok) {
-      const {message} = await response.json()
-
-      throw new Error(message)
-    }
-
-    return response.json()
-  } catch {
-    throw new Error('Une erreur a été rencontrée lors de l’ajout de l’administrateur.')
+  if (!response.ok) {
+    const {message} = await response.json()
+    throw new Error(message)
   }
+
+  return response.json()
 }
 
 export async function deleteAdministrator(adminId, token) {
-  try {
-    const response = await fetch(`/administrators/${adminId}`, {
-      method: 'DELETE',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Token ${token}`
-      }
-    })
-
-    if (!response.ok) {
-      const {message} = await response.json()
-
-      throw new Error(message)
+  const response = await fetch(`/administrators/${adminId}`, {
+    method: 'DELETE',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Token ${token}`
     }
+  })
 
-    return response
-  } catch {
-    throw new Error('Une erreur a été rencontrée lors de la suppression de l’administrateur.')
+  if (!response.ok) {
+    const {message} = await response.json()
+    throw new Error(message)
   }
+
+  return response
 }
 
 export async function resetEditCode(projetId, token) {

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -229,7 +229,7 @@ export async function addAdministator(token, administrator) {
 
 export async function deleteAdministrator(adminId, token) {
   try {
-    const response = await fetch(`/adminisrators/${adminId}`, {
+    const response = await fetch(`/administrators/${adminId}`, {
       method: 'DELETE',
       headers: {
         Accept: 'application/json',

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -192,37 +192,44 @@ export async function getAdministrators(token) {
     })
 
     if (!response.ok) {
-      throw new HttpError(response)
+      const {message} = await response.json()
+
+      throw new Error(message)
     }
 
     return response.json()
-  } catch (error) {
-    throw new HttpError(error)
+  } catch {
+    throw new Error('Une erreur a été rencontrée lors de la récupération des administrateurs.')
   }
 }
 
 export async function addAdministator(token, administrator) {
-  const response = await fetch('/administrators', {
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-      Authorization: `Token ${token}`
-    },
-    body: JSON.stringify(administrator)
-  })
+  try {
+    const response = await fetch('/administrators', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Token ${token}`
+      },
+      body: JSON.stringify(administrator)
+    })
 
-  if (!response.ok) {
-    const error = await response.json()
-    throw new Error(error.message)
+    if (!response.ok) {
+      const {message} = await response.json()
+
+      throw new Error(message)
+    }
+
+    return response.json()
+  } catch {
+    throw new Error('Une erreur a été rencontrée lors de l’ajout de l’administrateur.')
   }
-
-  return response.json()
 }
 
 export async function deleteAdministrator(adminId, token) {
   try {
-    const response = await fetch(`/administrators/${adminId}`, {
+    const response = await fetch(`/adminisrators/${adminId}`, {
       method: 'DELETE',
       headers: {
         Accept: 'application/json',
@@ -232,12 +239,14 @@ export async function deleteAdministrator(adminId, token) {
     })
 
     if (!response.ok) {
-      throw new HttpError(response)
+      const {message} = await response.json()
+
+      throw new Error(message)
     }
 
     return response
-  } catch (error) {
-    throw new HttpError(error)
+  } catch {
+    throw new Error('Une erreur a été rencontrée lors de la suppression de l’administrateur.')
   }
 }
 

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -180,6 +180,67 @@ export async function deleteCreator(emailId, token) {
   }
 }
 
+export async function getAdministrators(token) {
+  try {
+    const response = await fetch('/administrators', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Token ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new HttpError(response)
+    }
+
+    return response.json()
+  } catch (error) {
+    throw new HttpError(error)
+  }
+}
+
+export async function addAdministator(token, administrator) {
+  const response = await fetch('/administrators', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Token ${token}`
+    },
+    body: JSON.stringify(administrator)
+  })
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.message)
+  }
+
+  return response.json()
+}
+
+export async function deleteAdministrator(adminId, token) {
+  try {
+    const response = await fetch(`/administrators/${adminId}`, {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Token ${token}`
+      }
+    })
+
+    if (!response.ok) {
+      throw new HttpError(response)
+    }
+
+    return response
+  } catch (error) {
+    throw new HttpError(error)
+  }
+}
+
 export async function resetEditCode(projetId, token) {
   try {
     const response = await fetch(`/projets/${projetId}/renew-editor-key`, {
@@ -209,4 +270,3 @@ export async function getAllChanges(token) {
 
   return response.json()
 }
-

--- a/pages/gestion-suivi.js
+++ b/pages/gestion-suivi.js
@@ -9,6 +9,7 @@ import Page from '@/layouts/main.js'
 import AdminAuthentificationModal from '@/components/suivi-form/authentification/admin-authentification-modal.js'
 import Porteurs from '@/components/gestion-admin/porteurs.js'
 import Changes from '@/components/gestion-admin/changes.js'
+import Administrateurs from '@/components/gestion-admin/administrateurs.js'
 
 const Admin = () => {
   const router = useRouter()
@@ -94,7 +95,7 @@ const Admin = () => {
 
           {activeTab === 'admin' && (
             <div className='fr-tabs__panel fr-tabs__panel--selected' role='tabpanel'>
-              <i>Bientôt disponible</i>
+              <Administrateurs />
             </div>
           )}
 


### PR DESCRIPTION
**⚠️ Ne pas merger avant la PR Ajout d’une API pour la gestion des administrateurs [#253 ](https://github.com/openpcrs/pcrs.beta.gouv.fr/pull/253)**

La page `/gestion-suivi` permet à présent d'afficher la liste des administrateurs et de les gérer.
Au même titre que pour les porteurs, il est possible : 

- De rajouter un administrateur
- De supprimer un administrateur (autre que soit-même)
- De consulter les administrateurs actifs, les rechercher via une barre de recherche et trier leur ordre d'apparition.

L'utilisateur identifié se verra apparaitre dans la liste avec une icône différente.

### **Blocage de l'auto-suppression**
<img width="1273" alt="Capture d’écran 2023-07-25 à 17 01 17" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/efe38f9b-faeb-4f20-b9d4-63e6c4fc3af2">

------------------------
### **Ajout d'un administrateur**
<img width="1418" alt="Capture d’écran 2023-07-25 à 17 01 05" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/1fc3bc7a-5149-4d33-8eb4-01cd1c5a87ea">

------------------------
### **Liste des administrateurs**
<img width="1440" alt="Capture d’écran 2023-07-25 à 17 00 29" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/eb48c499-95d5-4da6-bf08-7b28b19729b4">

