### PR TITLE
Ajout d'un lien vers Data.gouv

### DIFF
--- a/layouts/map.js
+++ b/layouts/map.js
@@ -1,6 +1,8 @@
 import {useContext} from 'react'
 import PropTypes from 'prop-types'
 
+import colors from '@/styles/colors.js'
+
 import DeviceContext from '@/contexts/device.js'
 
 import Map from '@/components/map/index.js'
@@ -17,10 +19,18 @@ export const Mobile = ({handleClick, handleTitleClick, projet, isOpen, setIsOpen
         contain: 'content'
       }}
     >
+      {!isOpen && (
+        <div className='fr-p-1w fr-text--sm fr-m-0 fr-grid-row fr-grid-row--middle fr-grid-row--center' style={{background: colors.info975, textAlign: 'center'}}>
+          <div>
+            Les données de cette carte sont disponibles publiquement sur le site&nbsp;<a rel='noreferrer' href='https://www.data.gouv.fr/fr/organizations/pcrs-beta-gouv-fr/' target='_blank' title='ouvre un onglet vers data gouv'>Data gouv</a>
+          </div>
+        </div>
+      )}
+
       {geometry && (
         <div
           style={{
-            height: isOpen ? 0 : viewHeight - 204,
+            height: isOpen ? 0 : viewHeight - 264,
             width: '100%'
           }}
         >
@@ -34,7 +44,7 @@ export const Mobile = ({handleClick, handleTitleClick, projet, isOpen, setIsOpen
       )}
       <div
         style={{
-          height: isOpen ? viewHeight - 147 : '46px',
+          height: isOpen ? viewHeight - 147 : '56px',
           overflowY: isOpen ? 'auto' : 'hidden',
           overflowX: 'hidden',
           padding: '2px',
@@ -121,6 +131,7 @@ Mobile.propTypes = {
 export const Desktop = ({handleClick, projet, isOpen, setIsOpen, geometry, onProjetChange, projets}) => (
   <div
     style={{
+      height: '100%',
       display: 'flex',
       contain: 'content'
     }}
@@ -150,7 +161,7 @@ export const Desktop = ({handleClick, projet, isOpen, setIsOpen, geometry, onPro
           className={`fr-icon-arrow-${isOpen ? 'left' : 'right'}-s-line`}
           style={{
             position: 'absolute',
-            top: '25px',
+            top: '45px',
             left: isOpen ? '460px' : '5px',
             backgroundColor: 'white',
             height: '50px',
@@ -169,13 +180,21 @@ export const Desktop = ({handleClick, projet, isOpen, setIsOpen, geometry, onPro
     )}
 
     {geometry && (
-      <div style={{width: '100%', height: 'calc(100vh - 117px)'}}>
-        <Map
-          style={{pointerEvents: 'all'}}
-          handleClick={handleClick}
-          geometry={geometry}
-          projetId={projet?._id}
-        />
+      <div style={{width: '100%'}}>
+        <div className='fr-p-1w fr-text--sm fr-m-0 fr-grid-row fr-grid-row--middle fr-grid-row--center' style={{background: colors.info975, textAlign: 'center'}}>
+          <div>
+            Les données de cette carte sont disponibles publiquement sur le site&nbsp;<a rel='noreferrer' href='https://www.data.gouv.fr/fr/organizations/pcrs-beta-gouv-fr/' target='_blank' title='ouvre un onglet vers data gouv'>Data gouv</a>
+          </div>
+        </div>
+
+        <div style={{width: '100%', height: 'calc(100vh - 157px)'}}>
+          <Map
+            style={{pointerEvents: 'all'}}
+            handleClick={handleClick}
+            geometry={geometry}
+            projetId={projet?._id}
+          />
+        </div>
       </div>
     )}
   </div>

--- a/styles/colors.js
+++ b/styles/colors.js
@@ -15,6 +15,7 @@ export default ({
   blueFrance975: '#f5f5fe',
   info200: '#273961',
   info425: '#0063cb',
+  info975: '#f4f6ff',
   blueHover: '#1212FF',
 
   // Green


### PR DESCRIPTION
Ajout d'un texte informatif indiquant que les données de cette carte sont disponibles publiquement sur le site Data gouv.
Un lien redirige vers la page concernant le pcrs`https://www.data.gouv.fr/fr/organizations/pcrs-beta-gouv-fr/`

### **Desktop**
<img width="1440" alt="Capture d’écran 2023-07-27 à 13 08 30" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/239676d9-dd0c-4544-aad6-f9daa58c5785">

 ---------------------------------

### **Mobile**
<img width="385" alt="Capture d’écran 2023-07-27 à 13 09 14" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/0c98b85b-45d3-42f4-b8dc-4eefb9c82303">
