### PR TITLE
Corrige un problème de superposition du bouton et de la boite à outils de la carte

### DIFF
--- a/components/map/map-tool-box.js
+++ b/components/map/map-tool-box.js
@@ -13,7 +13,8 @@ const MapToolBox = ({children}) => {
         padding: '3px',
         borderRadius: '5px',
         width: isOpen ? '300px' : '',
-        border: '2px solid #dfdbd8'
+        border: '2px solid #dfdbd8',
+        zIndex: 2
       }}
     >
       {isOpen ? (

--- a/layouts/map.js
+++ b/layouts/map.js
@@ -40,7 +40,7 @@ export const Mobile = ({handleClick, handleTitleClick, projet, isOpen, setIsOpen
           padding: '2px',
           border: '1px solid lightgrey',
           borderBottom: '0',
-          zIndex: 5
+          zIndex: isOpen ? 3 : 0
         }}
       >
         <div


### PR DESCRIPTION
Cette PR corrige un problème de superposition des éléments sur la carte.
En version mobile, le bouton "Ajouter un projet" était placé au-dessus de la boite à outils lorsque celle-ci était ouverte.

- Ajout d’un `z-index: 2` sur le composant `MapToolBox`

### Captures : 
#### Avant : 

![Capture d’écran 2023-07-31 à 11 55 41](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/e6a8c38e-888d-4c46-8cf7-37427c462c35)

#### Après : 

![Capture d’écran 2023-07-31 à 11 56 08](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/adc88dff-3a9b-4d48-aa4e-b6a34f50bb86)
