### PR TITLE
Export des routes dans différents fichiers

### DIFF
--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -100,7 +100,7 @@ export async function deleteSuivi(id, token) {
 
 export async function getCreators(token) {
   try {
-    const response = await fetch('/creator-emails', {
+    const response = await fetch('/creators-emails', {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -121,7 +121,7 @@ export async function getCreators(token) {
 
 export async function getCreator(token, creatorId) {
   try {
-    const response = await fetch(`/creator-email/${creatorId}`, {
+    const response = await fetch(`/creators-emails/${creatorId}`, {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -141,7 +141,7 @@ export async function getCreator(token, creatorId) {
 }
 
 export async function addCreator(token, creator) {
-  const response = await fetch('/creator-emails', {
+  const response = await fetch('/creators-emails', {
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -161,7 +161,7 @@ export async function addCreator(token, creator) {
 
 export async function deleteCreator(emailId, token) {
   try {
-    const response = await fetch(`/creator-email/${emailId}`, {
+    const response = await fetch(`/creators-emails/${emailId}`, {
       method: 'DELETE',
       headers: {
         Accept: 'application/json',

--- a/server/index.js
+++ b/server/index.js
@@ -17,9 +17,10 @@ import mongo from './util/mongo.js'
 import errorHandler from './util/error-handler.js'
 import w from './util/w.js'
 
-import {handleAuth} from './auth/middleware.js'
+import {handleAuth, ensureAdmin} from './auth/middleware.js'
 
 import {getProjetsGeojson} from './projets.js'
+import {getUpdatedProjets} from './admin/reports.js'
 import dataRoutes from './routes/data.js'
 import projetsRoutes from './routes/projets.js'
 import authRoutes from './routes/auth.js'
@@ -51,6 +52,14 @@ server.use('/projets', projetsRoutes)
 server.use('/', authRoutes)
 server.use('/creators-emails', creatorsEmailsRoutes)
 server.use('/administrators', administratorsRoutes)
+
+creatorsEmailsRoutes.get('/report', w(ensureAdmin), w(async (req, res) => {
+  const since = new Date(req.query.since)
+  const validDate = Number.isNaN(since.valueOf()) ? new Date('2010-01-01') : since
+
+  const report = await getUpdatedProjets(validDate)
+  res.send(report)
+}))
 
 server.use(errorHandler)
 

--- a/server/index.js
+++ b/server/index.js
@@ -12,20 +12,19 @@ import process from 'node:process'
 import express from 'express'
 import next from 'next'
 import morgan from 'morgan'
-import createError from 'http-errors'
 
 import mongo from './util/mongo.js'
 import errorHandler from './util/error-handler.js'
 import w from './util/w.js'
 
-import {handleAuth, ensureAdmin, parseToken} from './auth/middleware.js'
+import {handleAuth} from './auth/middleware.js'
 
 import {getProjetsGeojson} from './projets.js'
 import dataRoutes from './routes/data.js'
 import projetsRoutes from './routes/projets.js'
 import authRoutes from './routes/auth.js'
 import creatorsEmailsRoutes from './routes/creators-emails.js'
-import {addAdministrator, getAdministrators, updateAdministrator, deleteAdministrator, getAdministratorById, isSelfDeleting} from './admin/administrators.js'
+import administratorsRoutes from './routes/administrators.js'
 
 const port = process.env.PORT || 3000
 const dev = process.env.NODE_ENV !== 'production'
@@ -43,18 +42,6 @@ if (dev) {
   server.use(morgan('dev'))
 }
 
-server.param('adminId', w(async (req, res, next) => {
-  const {adminId} = req.params
-  const administrator = await getAdministratorById(adminId, req)
-
-  if (!administrator) {
-    throw createError(404, 'Cet administrateur n’existe pas')
-  }
-
-  req.administrator = administrator
-  next()
-}))
-
 // Pre-warm underlying cache
 await getProjetsGeojson()
 
@@ -63,38 +50,7 @@ server.use('/', dataRoutes)
 server.use('/', projetsRoutes)
 server.use('/', authRoutes)
 server.use('/', creatorsEmailsRoutes)
-
-server.route('/administrators/:adminId')
-  .all(w(ensureAdmin))
-  .get(w(async (req, res) => {
-    res.send(req.administrator)
-  }))
-  .delete(w(async (req, res) => {
-    const token = await parseToken(req)
-
-    await isSelfDeleting(req.params.adminId, token)
-    await deleteAdministrator(req.params.adminId)
-
-    res.sendStatus(204)
-  }))
-  .put(w(async (req, res) => {
-    const administrator = await updateAdministrator(req.params.adminId, req.body)
-
-    res.send(administrator)
-  }))
-
-server.route('/administrators')
-  .all(w(ensureAdmin))
-  .get(w(async (req, res) => {
-    const administrators = await getAdministrators()
-
-    res.send(administrators)
-  }))
-  .post(w(async (req, res) => {
-    const administrator = await addAdministrator(req.body)
-
-    res.send(administrator)
-  }))
+server.use('/administrators', administratorsRoutes)
 
 server.use(errorHandler)
 

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,6 @@ dotenv.config()
 import process from 'node:process'
 
 import express from 'express'
-import createError from 'http-errors'
 import next from 'next'
 import morgan from 'morgan'
 
@@ -18,14 +17,13 @@ import mongo from './util/mongo.js'
 import errorHandler from './util/error-handler.js'
 import w from './util/w.js'
 
-import {handleAuth, ensureAdmin} from './auth/middleware.js'
+import {handleAuth} from './auth/middleware.js'
 
 import {getProjetsGeojson} from './projets.js'
-import {addCreator, deleteCreator, getCreatorById, getCreators, updateCreator} from './admin/creators-emails.js'
-import {getUpdatedProjets} from './admin/reports.js'
 import exportCSVRouter from './routes/data.js'
 import projetsRouter from './routes/projets.js'
 import exportAuthRouter from './routes/auth.js'
+import adminRoutes from './routes/admin.js'
 
 const port = process.env.PORT || 3000
 const dev = process.env.NODE_ENV !== 'production'
@@ -50,48 +48,7 @@ server.use(w(handleAuth))
 server.use('/', exportCSVRouter)
 server.use('/', projetsRouter)
 server.use('/', exportAuthRouter)
-
-server.route('/creator-email/:emailId')
-  .get(w(ensureAdmin), w(async (req, res) => {
-    const email = await getCreatorById(req.params.emailId)
-
-    if (!email) {
-      throw createError(404, 'Email introuvable')
-    }
-
-    res.send(email)
-  }))
-  .delete(w(ensureAdmin), w(async (req, res) => {
-    await deleteCreator(req.params.emailId)
-
-    res.sendStatus(204)
-  }))
-  .put(w(ensureAdmin), w(async (req, res) => {
-    const email = await updateCreator(req.params.emailId, req.body)
-
-    res.send(email)
-  }))
-
-server.route('/creator-emails')
-  .get(w(ensureAdmin), w(async (req, res) => {
-    const emails = await getCreators()
-
-    res.send(emails)
-  }))
-  .post(w(ensureAdmin), w(async (req, res) => {
-    const email = await addCreator(req.body)
-
-    res.send(email)
-  }))
-
-server.route('/report')
-  .get(w(ensureAdmin), w(async (req, res) => {
-    const since = new Date(req.query.since)
-    const validDate = Number.isNaN(since.valueOf()) ? new Date('2010-01-01') : since
-
-    const report = await getUpdatedProjets(validDate)
-    res.send(report)
-  }))
+server.use('/', adminRoutes)
 
 server.use(errorHandler)
 

--- a/server/index.js
+++ b/server/index.js
@@ -24,7 +24,7 @@ import {getProjetsGeojson} from './projets.js'
 import dataRoutes from './routes/data.js'
 import projetsRoutes from './routes/projets.js'
 import authRoutes from './routes/auth.js'
-import adminRoutes from './routes/admin.js'
+import creatorsEmailsRoutes from './routes/creators-emails.js'
 import {addAdministrator, getAdministrators, updateAdministrator, deleteAdministrator, getAdministratorById, isSelfDeleting} from './admin/administrators.js'
 
 const port = process.env.PORT || 3000
@@ -62,7 +62,7 @@ server.use(w(handleAuth))
 server.use('/', dataRoutes)
 server.use('/', projetsRoutes)
 server.use('/', authRoutes)
-server.use('/', adminRoutes)
+server.use('/', creatorsEmailsRoutes)
 
 server.route('/administrators/:adminId')
   .all(w(ensureAdmin))

--- a/server/index.js
+++ b/server/index.js
@@ -20,9 +20,9 @@ import w from './util/w.js'
 import {handleAuth} from './auth/middleware.js'
 
 import {getProjetsGeojson} from './projets.js'
-import exportCSVRouter from './routes/data.js'
 import projetsRouter from './routes/projets.js'
 import exportAuthRouter from './routes/auth.js'
+import dataRoutes from './routes/data.js'
 import adminRoutes from './routes/admin.js'
 
 const port = process.env.PORT || 3000
@@ -45,9 +45,9 @@ if (dev) {
 await getProjetsGeojson()
 
 server.use(w(handleAuth))
-server.use('/', exportCSVRouter)
 server.use('/', projetsRouter)
 server.use('/', exportAuthRouter)
+server.use('/', dataRoutes)
 server.use('/', adminRoutes)
 
 server.use(errorHandler)

--- a/server/index.js
+++ b/server/index.js
@@ -53,7 +53,7 @@ server.use('/', authRoutes)
 server.use('/creators-emails', creatorsEmailsRoutes)
 server.use('/administrators', administratorsRoutes)
 
-creatorsEmailsRoutes.get('/report', w(ensureAdmin), w(async (req, res) => {
+server.get('/report', w(ensureAdmin), w(async (req, res) => {
   const since = new Date(req.query.since)
   const validDate = Number.isNaN(since.valueOf()) ? new Date('2010-01-01') : since
 

--- a/server/index.js
+++ b/server/index.js
@@ -22,9 +22,9 @@ import {handleAuth, ensureCreator, ensureProjectEditor, ensureAdmin} from './aut
 import {sendPinCodeEmail, checkPinCodeValidity} from './auth/pin-code/index.js'
 
 import {getProjet, getProjets, deleteProjet, updateProjet, getProjetsGeojson, expandProjet, filterSensitiveFields, createProjet, renewEditorKey} from './projets.js'
-import {exportEditorKeys, exportLivrablesAsCSV, exportProjetsAsCSV, exportSubventionsAsCSV, exportToursDeTableAsCSV} from '../lib/export/csv.js'
 import {addCreator, deleteCreator, getCreatorById, getCreators, updateCreator, getCreatorByEmail} from './admin/creators-emails.js'
 import {getUpdatedProjets} from './admin/reports.js'
+import exportCSVRouter from './routes/data.js'
 
 const port = process.env.PORT || 3000
 const dev = process.env.NODE_ENV !== 'production'
@@ -58,6 +58,8 @@ server.param('projetId', w(async (req, res, next) => {
 await getProjetsGeojson()
 
 server.use(w(handleAuth))
+
+server.use('/', exportCSVRouter)
 
 server.route('/projets/geojson')
   .get(w(async (req, res) => {
@@ -106,41 +108,6 @@ server.route('/projets')
     const expandedProjet = expandProjet(projet)
 
     res.status(201).send(expandedProjet)
-  }))
-
-server.route('/data/projets.csv')
-  .get(w(async (req, res) => {
-    const projetsCSVFile = await exportProjetsAsCSV(req.query.includesWkt === '1')
-
-    res.attachment('projets.csv').type('csv').send(projetsCSVFile)
-  }))
-
-server.route('/data/livrables.csv')
-  .get(w(async (req, res) => {
-    const livrablesCSVFile = await exportLivrablesAsCSV()
-
-    res.attachment('livrables.csv').type('csv').send(livrablesCSVFile)
-  }))
-
-server.route('/data/tours-de-table.csv')
-  .get(w(async (req, res) => {
-    const toursDeTableCSVFile = await exportToursDeTableAsCSV()
-
-    res.attachment('tours-de-table.csv').type('csv').send(toursDeTableCSVFile)
-  }))
-
-server.route('/data/subventions.csv')
-  .get(w(async (req, res) => {
-    const subventionsCSVFile = await exportSubventionsAsCSV()
-
-    res.attachment('subventions.csv').type('csv').send(subventionsCSVFile)
-  }))
-
-server.route('/data/editor-keys.csv')
-  .get(w(ensureAdmin), w(async (req, res) => {
-    const editorKeysCSVFile = await exportEditorKeys()
-
-    res.attachment('editor-keys.csv').type('csv').send(editorKeysCSVFile)
   }))
 
 server.route('/ask-code')

--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,7 @@ await getProjetsGeojson()
 
 server.use(w(handleAuth))
 server.use('/data', dataRoutes)
-server.use('/', projetsRoutes)
+server.use('/projets', projetsRoutes)
 server.use('/', authRoutes)
 server.use('/', creatorsEmailsRoutes)
 server.use('/administrators', administratorsRoutes)

--- a/server/index.js
+++ b/server/index.js
@@ -17,15 +17,15 @@ import mongo from './util/mongo.js'
 import errorHandler from './util/error-handler.js'
 import w from './util/w.js'
 
-import {handleAuth, ensureAdmin} from './auth/middleware.js'
+import {handleAuth} from './auth/middleware.js'
 
 import {getProjetsGeojson} from './projets.js'
-import {getUpdatedProjets} from './admin/reports.js'
 import dataRoutes from './routes/data.js'
 import projetsRoutes from './routes/projets.js'
 import authRoutes from './routes/auth.js'
 import creatorsEmailsRoutes from './routes/creators-emails.js'
 import administratorsRoutes from './routes/administrators.js'
+import reportRoutes from './routes/report.js'
 
 const port = process.env.PORT || 3000
 const dev = process.env.NODE_ENV !== 'production'
@@ -52,14 +52,7 @@ server.use('/projets', projetsRoutes)
 server.use('/', authRoutes)
 server.use('/creators-emails', creatorsEmailsRoutes)
 server.use('/administrators', administratorsRoutes)
-
-server.get('/report', w(ensureAdmin), w(async (req, res) => {
-  const since = new Date(req.query.since)
-  const validDate = Number.isNaN(since.valueOf()) ? new Date('2010-01-01') : since
-
-  const report = await getUpdatedProjets(validDate)
-  res.send(report)
-}))
+server.use('/report', reportRoutes)
 
 server.use(errorHandler)
 

--- a/server/index.js
+++ b/server/index.js
@@ -20,9 +20,9 @@ import w from './util/w.js'
 import {handleAuth} from './auth/middleware.js'
 
 import {getProjetsGeojson} from './projets.js'
-import projetsRouter from './routes/projets.js'
 import exportAuthRouter from './routes/auth.js'
 import dataRoutes from './routes/data.js'
+import projetsRoutes from './routes/projets.js'
 import adminRoutes from './routes/admin.js'
 
 const port = process.env.PORT || 3000
@@ -45,9 +45,9 @@ if (dev) {
 await getProjetsGeojson()
 
 server.use(w(handleAuth))
-server.use('/', projetsRouter)
 server.use('/', exportAuthRouter)
 server.use('/', dataRoutes)
+server.use('/', projetsRoutes)
 server.use('/', adminRoutes)
 
 server.use(errorHandler)

--- a/server/index.js
+++ b/server/index.js
@@ -49,7 +49,7 @@ server.use(w(handleAuth))
 server.use('/data', dataRoutes)
 server.use('/projets', projetsRoutes)
 server.use('/', authRoutes)
-server.use('/', creatorsEmailsRoutes)
+server.use('/creators-emails', creatorsEmailsRoutes)
 server.use('/administrators', administratorsRoutes)
 
 server.use(errorHandler)

--- a/server/index.js
+++ b/server/index.js
@@ -20,9 +20,9 @@ import w from './util/w.js'
 import {handleAuth} from './auth/middleware.js'
 
 import {getProjetsGeojson} from './projets.js'
-import exportAuthRouter from './routes/auth.js'
 import dataRoutes from './routes/data.js'
 import projetsRoutes from './routes/projets.js'
+import authRoutes from './routes/auth.js'
 import adminRoutes from './routes/admin.js'
 
 const port = process.env.PORT || 3000
@@ -45,9 +45,9 @@ if (dev) {
 await getProjetsGeojson()
 
 server.use(w(handleAuth))
-server.use('/', exportAuthRouter)
 server.use('/', dataRoutes)
 server.use('/', projetsRoutes)
+server.use('/', authRoutes)
 server.use('/', adminRoutes)
 
 server.use(errorHandler)

--- a/server/index.js
+++ b/server/index.js
@@ -46,7 +46,7 @@ if (dev) {
 await getProjetsGeojson()
 
 server.use(w(handleAuth))
-server.use('/', dataRoutes)
+server.use('/data', dataRoutes)
 server.use('/', projetsRoutes)
 server.use('/', authRoutes)
 server.use('/', creatorsEmailsRoutes)

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,0 +1,52 @@
+import express from 'express'
+import createError from 'http-errors'
+import w from '../util/w.js'
+import {addCreator, deleteCreator, getCreatorById, getCreators, updateCreator} from '../admin/creators-emails.js'
+import {ensureAdmin} from '../auth/middleware.js'
+import {getUpdatedProjets} from '../admin/reports.js'
+
+const adminRoutes = new express.Router()
+
+adminRoutes.get('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
+  const email = await getCreatorById(req.params.emailId)
+
+  if (!email) {
+    throw createError(404, 'Email introuvable')
+  }
+
+  res.send(email)
+}))
+
+adminRoutes.delete('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
+  await deleteCreator(req.params.emailId)
+
+  res.status(204)
+}))
+
+adminRoutes.put('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
+  const email = await updateCreator(req.params.emailId, req.body)
+
+  res.send(email)
+}))
+
+adminRoutes.get('/creator-emails', w(ensureAdmin), w(async (req, res) => {
+  const emails = await getCreators()
+
+  res.send(emails)
+}))
+
+adminRoutes.post('/creator-emails', w(ensureAdmin), w(async (req, res) => {
+  const email = await addCreator(req.body)
+
+  res.send(email)
+}))
+
+adminRoutes.get('/report', w(ensureAdmin), w(async (req, res) => {
+  const since = new Date(req.query.since)
+  const validDate = Number.isNaN(since.valueOf()) ? new Date('2010-01-01') : since
+
+  const report = await getUpdatedProjets(validDate)
+  res.send(report)
+}))
+
+export default adminRoutes

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -20,7 +20,7 @@ adminRoutes.get('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) =>
 adminRoutes.delete('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
   await deleteCreator(req.params.emailId)
 
-  res.status(204)
+  res.sendStatus(204)
 }))
 
 adminRoutes.put('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {

--- a/server/routes/administrators.js
+++ b/server/routes/administrators.js
@@ -1,0 +1,54 @@
+import express from 'express'
+import createError from 'http-errors'
+import w from '../util/w.js'
+
+import {ensureAdmin, parseToken} from '../auth/middleware.js'
+import {addAdministrator, deleteAdministrator, getAdministratorById, getAdministrators, isSelfDeleting, updateAdministrator} from '../admin/administrators.js'
+
+const administratorsRoutes = new express.Router()
+
+administratorsRoutes.param('adminId', w(async (req, res, next) => {
+  const {adminId} = req.params
+  const administrator = await getAdministratorById(adminId, req)
+
+  if (!administrator) {
+    throw createError(404, 'Cet administrateur n’existe pas')
+  }
+
+  req.administrator = administrator
+  next()
+}))
+
+administratorsRoutes.route('/:adminId')
+  .all(w(ensureAdmin))
+  .get(w(async (req, res) => {
+    res.send(req.administrator)
+  }))
+  .delete(w(async (req, res) => {
+    const token = await parseToken(req)
+
+    await isSelfDeleting(req.params.adminId, token)
+    await deleteAdministrator(req.params.adminId)
+
+    res.sendStatus(204)
+  }))
+  .put(w(async (req, res) => {
+    const administrator = await updateAdministrator(req.params.adminId, req.body)
+
+    res.send(administrator)
+  }))
+
+administratorsRoutes.route('/')
+  .all(w(ensureAdmin))
+  .get(w(async (req, res) => {
+    const administrators = await getAdministrators()
+
+    res.send(administrators)
+  }))
+  .post(w(async (req, res) => {
+    const administrator = await addAdministrator(req.body)
+
+    res.send(administrator)
+  }))
+
+export default administratorsRoutes

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,38 @@
+import express from 'express'
+import createError from 'http-errors'
+import w from '../util/w.js'
+
+import {sendPinCodeEmail} from '../auth/index.js'
+import {checkPinCodeValidity} from '../auth/pin-code.js'
+import {getCreatorByEmail} from '../admin/creators-emails.js'
+
+const exportAuthRouter = new express.Router()
+
+exportAuthRouter.post('/ask-code', w(async (req, res) => {
+  const authorizedEditorEmail = await getCreatorByEmail(req.body.email)
+
+  if (!authorizedEditorEmail) {
+    throw createError(401, 'Cette adresse n’est pas autorisée à créer un projet')
+  }
+
+  await sendPinCodeEmail(req.body.email)
+
+  res.status(201).send('ok')
+}))
+
+exportAuthRouter.post('/check-code', w(async (req, res) => {
+  const {email, pinCode} = req.body
+  const validToken = await checkPinCodeValidity({email, pinCode})
+
+  res.send({token: validToken})
+}))
+
+exportAuthRouter.get('/me', w(async (req, res) => {
+  if (!req.role) {
+    throw createError(401, 'Jeton requis')
+  }
+
+  res.send({role: req.role})
+}))
+
+export default exportAuthRouter

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -2,8 +2,7 @@ import express from 'express'
 import createError from 'http-errors'
 import w from '../util/w.js'
 
-import {sendPinCodeEmail} from '../auth/index.js'
-import {checkPinCodeValidity} from '../auth/pin-code.js'
+import {checkPinCodeValidity, sendPinCodeEmail} from '../auth/pin-code.js'
 import {getCreatorByEmail} from '../admin/creators-emails.js'
 
 const authRoutes = new express.Router()

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -6,9 +6,9 @@ import {sendPinCodeEmail} from '../auth/index.js'
 import {checkPinCodeValidity} from '../auth/pin-code.js'
 import {getCreatorByEmail} from '../admin/creators-emails.js'
 
-const exportAuthRouter = new express.Router()
+const authRoutes = new express.Router()
 
-exportAuthRouter.post('/ask-code', w(async (req, res) => {
+authRoutes.post('/ask-code', w(async (req, res) => {
   const authorizedEditorEmail = await getCreatorByEmail(req.body.email)
 
   if (!authorizedEditorEmail) {
@@ -20,14 +20,14 @@ exportAuthRouter.post('/ask-code', w(async (req, res) => {
   res.status(201).send('ok')
 }))
 
-exportAuthRouter.post('/check-code', w(async (req, res) => {
+authRoutes.post('/check-code', w(async (req, res) => {
   const {email, pinCode} = req.body
   const validToken = await checkPinCodeValidity({email, pinCode})
 
   res.send({token: validToken})
 }))
 
-exportAuthRouter.get('/me', w(async (req, res) => {
+authRoutes.get('/me', w(async (req, res) => {
   if (!req.role) {
     throw createError(401, 'Jeton requis')
   }
@@ -35,4 +35,4 @@ exportAuthRouter.get('/me', w(async (req, res) => {
   res.send({role: req.role})
 }))
 
-export default exportAuthRouter
+export default authRoutes

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -2,7 +2,7 @@ import express from 'express'
 import createError from 'http-errors'
 import w from '../util/w.js'
 
-import {checkPinCodeValidity, sendPinCodeEmail} from '../auth/pin-code.js'
+import {checkPinCodeValidity, sendPinCodeEmail} from '../auth/pin-code/index.js'
 import {getCreatorByEmail} from '../admin/creators-emails.js'
 
 const authRoutes = new express.Router()

--- a/server/routes/creators-emails.js
+++ b/server/routes/creators-emails.js
@@ -3,7 +3,6 @@ import createError from 'http-errors'
 import w from '../util/w.js'
 import {addCreator, deleteCreator, getCreatorById, getCreators, updateCreator} from '../admin/creators-emails.js'
 import {ensureAdmin} from '../auth/middleware.js'
-import {getUpdatedProjets} from '../admin/reports.js'
 
 const creatorsEmailsRoutes = new express.Router()
 
@@ -41,13 +40,5 @@ creatorsEmailsRoutes.route('/')
 
     res.send(email)
   }))
-
-creatorsEmailsRoutes.get('/report', w(ensureAdmin), w(async (req, res) => {
-  const since = new Date(req.query.since)
-  const validDate = Number.isNaN(since.valueOf()) ? new Date('2010-01-01') : since
-
-  const report = await getUpdatedProjets(validDate)
-  res.send(report)
-}))
 
 export default creatorsEmailsRoutes

--- a/server/routes/creators-emails.js
+++ b/server/routes/creators-emails.js
@@ -5,9 +5,9 @@ import {addCreator, deleteCreator, getCreatorById, getCreators, updateCreator} f
 import {ensureAdmin} from '../auth/middleware.js'
 import {getUpdatedProjets} from '../admin/reports.js'
 
-const adminRoutes = new express.Router()
+const creatorsEmailsRoutes = new express.Router()
 
-adminRoutes.get('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
+creatorsEmailsRoutes.get('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
   const email = await getCreatorById(req.params.emailId)
 
   if (!email) {
@@ -17,31 +17,31 @@ adminRoutes.get('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) =>
   res.send(email)
 }))
 
-adminRoutes.delete('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
+creatorsEmailsRoutes.delete('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
   await deleteCreator(req.params.emailId)
 
   res.sendStatus(204)
 }))
 
-adminRoutes.put('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
+creatorsEmailsRoutes.put('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
   const email = await updateCreator(req.params.emailId, req.body)
 
   res.send(email)
 }))
 
-adminRoutes.get('/creator-emails', w(ensureAdmin), w(async (req, res) => {
+creatorsEmailsRoutes.get('/creator-emails', w(ensureAdmin), w(async (req, res) => {
   const emails = await getCreators()
 
   res.send(emails)
 }))
 
-adminRoutes.post('/creator-emails', w(ensureAdmin), w(async (req, res) => {
+creatorsEmailsRoutes.post('/creator-emails', w(ensureAdmin), w(async (req, res) => {
   const email = await addCreator(req.body)
 
   res.send(email)
 }))
 
-adminRoutes.get('/report', w(ensureAdmin), w(async (req, res) => {
+creatorsEmailsRoutes.get('/report', w(ensureAdmin), w(async (req, res) => {
   const since = new Date(req.query.since)
   const validDate = Number.isNaN(since.valueOf()) ? new Date('2010-01-01') : since
 
@@ -49,4 +49,4 @@ adminRoutes.get('/report', w(ensureAdmin), w(async (req, res) => {
   res.send(report)
 }))
 
-export default adminRoutes
+export default creatorsEmailsRoutes

--- a/server/routes/creators-emails.js
+++ b/server/routes/creators-emails.js
@@ -7,39 +7,40 @@ import {getUpdatedProjets} from '../admin/reports.js'
 
 const creatorsEmailsRoutes = new express.Router()
 
-creatorsEmailsRoutes.get('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
-  const email = await getCreatorById(req.params.emailId)
+creatorsEmailsRoutes.route('/:emailId')
+  .all(w(ensureAdmin))
+  .get(w(async (req, res) => {
+    const email = await getCreatorById(req.params.emailId)
 
-  if (!email) {
-    throw createError(404, 'Email introuvable')
-  }
+    if (!email) {
+      throw createError(404, 'Email introuvable')
+    }
 
-  res.send(email)
-}))
+    res.send(email)
+  }))
+  .delete(w(async (req, res) => {
+    await deleteCreator(req.params.emailId)
 
-creatorsEmailsRoutes.delete('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
-  await deleteCreator(req.params.emailId)
+    res.sendStatus(204)
+  }))
+  .put(w(async (req, res) => {
+    const email = await updateCreator(req.params.emailId, req.body)
 
-  res.sendStatus(204)
-}))
+    res.send(email)
+  }))
 
-creatorsEmailsRoutes.put('/creator-email/:emailId', w(ensureAdmin), w(async (req, res) => {
-  const email = await updateCreator(req.params.emailId, req.body)
+creatorsEmailsRoutes.route('/')
+  .all(w(ensureAdmin))
+  .get(w(async (req, res) => {
+    const emails = await getCreators()
 
-  res.send(email)
-}))
+    res.send(emails)
+  }))
+  .post(w(async (req, res) => {
+    const email = await addCreator(req.body)
 
-creatorsEmailsRoutes.get('/creator-emails', w(ensureAdmin), w(async (req, res) => {
-  const emails = await getCreators()
-
-  res.send(emails)
-}))
-
-creatorsEmailsRoutes.post('/creator-emails', w(ensureAdmin), w(async (req, res) => {
-  const email = await addCreator(req.body)
-
-  res.send(email)
-}))
+    res.send(email)
+  }))
 
 creatorsEmailsRoutes.get('/report', w(ensureAdmin), w(async (req, res) => {
   const since = new Date(req.query.since)

--- a/server/routes/data.js
+++ b/server/routes/data.js
@@ -1,0 +1,39 @@
+import express from 'express'
+import {ensureAdmin} from '../auth/middleware.js'
+import w from '../util/w.js'
+
+import {exportProjetsAsCSV, exportLivrablesAsCSV, exportToursDeTableAsCSV, exportSubventionsAsCSV, exportEditorKeys} from '../../lib/export/csv.js'
+
+const exportCSVRouter = new express.Router()
+
+exportCSVRouter.get('/data/projets.csv', w(async (req, res) => {
+  const projetsCSVFile = await exportProjetsAsCSV(req.query.includesWkt === '1')
+
+  res.attachment('projets.csv').type('csv').send(projetsCSVFile)
+}))
+
+exportCSVRouter.get('/data/livrables.csv', w(async (req, res) => {
+  const livrablesCSVFile = await exportLivrablesAsCSV()
+
+  res.attachment('livrables.csv').type('csv').send(livrablesCSVFile)
+}))
+
+exportCSVRouter.get('/data/tours-de-table.csv', w(async (req, res) => {
+  const toursDeTableCSVFile = await exportToursDeTableAsCSV()
+
+  res.attachment('tours-de-table.csv').type('csv').send(toursDeTableCSVFile)
+}))
+
+exportCSVRouter.get('/data/subventions.csv', w(async (req, res) => {
+  const subventionsCSVFile = await exportSubventionsAsCSV()
+
+  res.attachment('subventions.csv').type('csv').send(subventionsCSVFile)
+}))
+
+exportCSVRouter.get('/data/editor-keys.csv', w(ensureAdmin), w(async (req, res) => {
+  const editorKeysCSVFile = await exportEditorKeys()
+
+  res.attachment('editor-keys.csv').type('csv').send(editorKeysCSVFile)
+}))
+
+export default exportCSVRouter

--- a/server/routes/data.js
+++ b/server/routes/data.js
@@ -6,31 +6,31 @@ import {exportProjetsAsCSV, exportLivrablesAsCSV, exportToursDeTableAsCSV, expor
 
 const dataRoutes = new express.Router()
 
-dataRoutes.get('/data/projets.csv', w(async (req, res) => {
+dataRoutes.get('/projets.csv', w(async (req, res) => {
   const projetsCSVFile = await exportProjetsAsCSV(req.query.includesWkt === '1')
 
   res.attachment('projets.csv').type('csv').send(projetsCSVFile)
 }))
 
-dataRoutes.get('/data/livrables.csv', w(async (req, res) => {
+dataRoutes.get('/livrables.csv', w(async (req, res) => {
   const livrablesCSVFile = await exportLivrablesAsCSV()
 
   res.attachment('livrables.csv').type('csv').send(livrablesCSVFile)
 }))
 
-dataRoutes.get('/data/tours-de-table.csv', w(async (req, res) => {
+dataRoutes.get('/tours-de-table.csv', w(async (req, res) => {
   const toursDeTableCSVFile = await exportToursDeTableAsCSV()
 
   res.attachment('tours-de-table.csv').type('csv').send(toursDeTableCSVFile)
 }))
 
-dataRoutes.get('/data/subventions.csv', w(async (req, res) => {
+dataRoutes.get('/subventions.csv', w(async (req, res) => {
   const subventionsCSVFile = await exportSubventionsAsCSV()
 
   res.attachment('subventions.csv').type('csv').send(subventionsCSVFile)
 }))
 
-dataRoutes.get('/data/editor-keys.csv', w(ensureAdmin), w(async (req, res) => {
+dataRoutes.get('/editor-keys.csv', w(ensureAdmin), w(async (req, res) => {
   const editorKeysCSVFile = await exportEditorKeys()
 
   res.attachment('editor-keys.csv').type('csv').send(editorKeysCSVFile)

--- a/server/routes/data.js
+++ b/server/routes/data.js
@@ -4,36 +4,36 @@ import w from '../util/w.js'
 
 import {exportProjetsAsCSV, exportLivrablesAsCSV, exportToursDeTableAsCSV, exportSubventionsAsCSV, exportEditorKeys} from '../../lib/export/csv.js'
 
-const exportCSVRouter = new express.Router()
+const dataRoutes = new express.Router()
 
-exportCSVRouter.get('/data/projets.csv', w(async (req, res) => {
+dataRoutes.get('/data/projets.csv', w(async (req, res) => {
   const projetsCSVFile = await exportProjetsAsCSV(req.query.includesWkt === '1')
 
   res.attachment('projets.csv').type('csv').send(projetsCSVFile)
 }))
 
-exportCSVRouter.get('/data/livrables.csv', w(async (req, res) => {
+dataRoutes.get('/data/livrables.csv', w(async (req, res) => {
   const livrablesCSVFile = await exportLivrablesAsCSV()
 
   res.attachment('livrables.csv').type('csv').send(livrablesCSVFile)
 }))
 
-exportCSVRouter.get('/data/tours-de-table.csv', w(async (req, res) => {
+dataRoutes.get('/data/tours-de-table.csv', w(async (req, res) => {
   const toursDeTableCSVFile = await exportToursDeTableAsCSV()
 
   res.attachment('tours-de-table.csv').type('csv').send(toursDeTableCSVFile)
 }))
 
-exportCSVRouter.get('/data/subventions.csv', w(async (req, res) => {
+dataRoutes.get('/data/subventions.csv', w(async (req, res) => {
   const subventionsCSVFile = await exportSubventionsAsCSV()
 
   res.attachment('subventions.csv').type('csv').send(subventionsCSVFile)
 }))
 
-exportCSVRouter.get('/data/editor-keys.csv', w(ensureAdmin), w(async (req, res) => {
+dataRoutes.get('/data/editor-keys.csv', w(ensureAdmin), w(async (req, res) => {
   const editorKeysCSVFile = await exportEditorKeys()
 
   res.attachment('editor-keys.csv').type('csv').send(editorKeysCSVFile)
 }))
 
-export default exportCSVRouter
+export default dataRoutes

--- a/server/routes/projets.js
+++ b/server/routes/projets.js
@@ -5,9 +5,9 @@ import w from '../util/w.js'
 import {ensureCreator, ensureAdmin, ensureProjectEditor} from '../auth/middleware.js'
 import {getProjets, expandProjet, filterSensitiveFields, createProjet, getProjet, getProjetsGeojson, renewEditorKey, deleteProjet, updateProjet} from '../projets.js'
 
-const projetsRouter = new express.Router()
+const projetsRoutes = new express.Router()
 
-projetsRouter.param('projetId', w(async (req, res, next) => {
+projetsRoutes.param('projetId', w(async (req, res, next) => {
   const {projetId} = req.params
   const projet = await getProjet(projetId, req)
 
@@ -19,18 +19,18 @@ projetsRouter.param('projetId', w(async (req, res, next) => {
   next()
 }))
 
-projetsRouter.get('/projets/geojson', w(async (req, res) => {
+projetsRoutes.get('/projets/geojson', w(async (req, res) => {
   const projetsGeojson = await getProjetsGeojson()
   res.send(projetsGeojson)
 }))
 
-projetsRouter.get('/projets/:projetId/renew-editor-key', w(ensureAdmin), w(async (req, res) => {
+projetsRoutes.get('/projets/:projetId/renew-editor-key', w(ensureAdmin), w(async (req, res) => {
   const updatedProjet = await renewEditorKey(req.projet)
 
   res.status(200).send(updatedProjet)
 }))
 
-projetsRouter.get('/projets/:projetId', w(async (req, res) => {
+projetsRoutes.get('/projets/:projetId', w(async (req, res) => {
   const projet = expandProjet(req.projet)
 
   if (req.role === 'admin' || (req.role === 'editor' && req.projet._id.equals(req.canEditProjetId))) {
@@ -40,19 +40,19 @@ projetsRouter.get('/projets/:projetId', w(async (req, res) => {
   res.send(filterSensitiveFields(projet))
 }))
 
-projetsRouter.delete('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {
+projetsRoutes.delete('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {
   await deleteProjet(req.projet._id)
   res.status(204)
 }))
 
-projetsRouter.put('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {
+projetsRoutes.put('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {
   const projet = await updateProjet(req.projet._id, req.body)
   const expandedProjet = expandProjet(projet)
 
   res.send(expandedProjet)
 }))
 
-projetsRouter.get('/projets', w(async (req, res) => {
+projetsRoutes.get('/projets', w(async (req, res) => {
   const projets = await getProjets()
 
   res.send(projets.map(
@@ -60,11 +60,11 @@ projetsRouter.get('/projets', w(async (req, res) => {
   ))
 }))
 
-projetsRouter.post('/projets', w(ensureCreator), w(async (req, res) => {
+projetsRoutes.post('/projets', w(ensureCreator), w(async (req, res) => {
   const projet = await createProjet(req.body, {creator: req.creator})
   const expandedProjet = expandProjet(projet)
 
   res.status(201).send(expandedProjet)
 }))
 
-export default projetsRouter
+export default projetsRoutes

--- a/server/routes/projets.js
+++ b/server/routes/projets.js
@@ -42,7 +42,7 @@ projetsRoutes.get('/projets/:projetId', w(async (req, res) => {
 
 projetsRoutes.delete('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {
   await deleteProjet(req.projet._id)
-  res.status(204)
+  res.sendStatus(204)
 }))
 
 projetsRoutes.put('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {

--- a/server/routes/projets.js
+++ b/server/routes/projets.js
@@ -19,52 +19,51 @@ projetsRoutes.param('projetId', w(async (req, res, next) => {
   next()
 }))
 
-projetsRoutes.get('/projets/geojson', w(async (req, res) => {
+projetsRoutes.get('/geojson', w(async (req, res) => {
   const projetsGeojson = await getProjetsGeojson()
   res.send(projetsGeojson)
 }))
 
-projetsRoutes.get('/projets/:projetId/renew-editor-key', w(ensureAdmin), w(async (req, res) => {
+projetsRoutes.get('/:projetId/renew-editor-key', w(ensureAdmin), w(async (req, res) => {
   const updatedProjet = await renewEditorKey(req.projet)
 
   res.status(200).send(updatedProjet)
 }))
 
-projetsRoutes.get('/projets/:projetId', w(async (req, res) => {
-  const projet = expandProjet(req.projet)
+projetsRoutes.route('/:projetId')
+  .get(w(async (req, res) => {
+    const projet = expandProjet(req.projet)
 
-  if (req.role === 'admin' || (req.role === 'editor' && req.projet._id.equals(req.canEditProjetId))) {
-    return res.send(projet)
-  }
+    if (req.role === 'admin' || (req.role === 'editor' && req.projet._id.equals(req.canEditProjetId))) {
+      return res.send(projet)
+    }
 
-  res.send(filterSensitiveFields(projet))
-}))
+    res.send(filterSensitiveFields(projet))
+  }))
+  .delete(w(ensureProjectEditor), w(async (req, res) => {
+    await deleteProjet(req.projet._id)
+    res.sendStatus(204)
+  }))
+  .put(w(ensureProjectEditor), w(async (req, res) => {
+    const projet = await updateProjet(req.projet._id, req.body)
+    const expandedProjet = expandProjet(projet)
 
-projetsRoutes.delete('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {
-  await deleteProjet(req.projet._id)
-  res.sendStatus(204)
-}))
+    res.send(expandedProjet)
+  }))
 
-projetsRoutes.put('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {
-  const projet = await updateProjet(req.projet._id, req.body)
-  const expandedProjet = expandProjet(projet)
+projetsRoutes.route('/')
+  .get(w(async (req, res) => {
+    const projets = await getProjets()
 
-  res.send(expandedProjet)
-}))
+    res.send(projets.map(
+      projet => expandProjet(filterSensitiveFields(projet))
+    ))
+  }))
+  .post(w(ensureCreator), w(async (req, res) => {
+    const projet = await createProjet(req.body, {creator: req.creator})
+    const expandedProjet = expandProjet(projet)
 
-projetsRoutes.get('/projets', w(async (req, res) => {
-  const projets = await getProjets()
-
-  res.send(projets.map(
-    projet => expandProjet(filterSensitiveFields(projet))
-  ))
-}))
-
-projetsRoutes.post('/projets', w(ensureCreator), w(async (req, res) => {
-  const projet = await createProjet(req.body, {creator: req.creator})
-  const expandedProjet = expandProjet(projet)
-
-  res.status(201).send(expandedProjet)
-}))
+    res.status(201).send(expandedProjet)
+  }))
 
 export default projetsRoutes

--- a/server/routes/projets.js
+++ b/server/routes/projets.js
@@ -1,0 +1,70 @@
+import express from 'express'
+import createError from 'http-errors'
+import w from '../util/w.js'
+
+import {ensureCreator, ensureAdmin, ensureProjectEditor} from '../auth/middleware.js'
+import {getProjets, expandProjet, filterSensitiveFields, createProjet, getProjet, getProjetsGeojson, renewEditorKey, deleteProjet, updateProjet} from '../projets.js'
+
+const projetsRouter = new express.Router()
+
+projetsRouter.param('projetId', w(async (req, res, next) => {
+  const {projetId} = req.params
+  const projet = await getProjet(projetId, req)
+
+  if (!projet) {
+    throw createError(404, 'L’identifiant de projet demandé n’existe pas')
+  }
+
+  req.projet = projet
+  next()
+}))
+
+projetsRouter.get('/projets/geojson', w(async (req, res) => {
+  const projetsGeojson = await getProjetsGeojson()
+  res.send(projetsGeojson)
+}))
+
+projetsRouter.get('/projets/:projetId/renew-editor-key', w(ensureAdmin), w(async (req, res) => {
+  const updatedProjet = await renewEditorKey(req.projet)
+
+  res.status(200).send(updatedProjet)
+}))
+
+projetsRouter.get('/projets/:projetId', w(async (req, res) => {
+  const projet = expandProjet(req.projet)
+
+  if (req.role === 'admin' || (req.role === 'editor' && req.projet._id.equals(req.canEditProjetId))) {
+    return res.send(projet)
+  }
+
+  res.send(filterSensitiveFields(projet))
+}))
+
+projetsRouter.delete('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {
+  await deleteProjet(req.projet._id)
+  res.status(204)
+}))
+
+projetsRouter.put('/projets/:projetId', w(ensureProjectEditor), w(async (req, res) => {
+  const projet = await updateProjet(req.projet._id, req.body)
+  const expandedProjet = expandProjet(projet)
+
+  res.send(expandedProjet)
+}))
+
+projetsRouter.get('/projets', w(async (req, res) => {
+  const projets = await getProjets()
+
+  res.send(projets.map(
+    projet => expandProjet(filterSensitiveFields(projet))
+  ))
+}))
+
+projetsRouter.post('/projets', w(ensureCreator), w(async (req, res) => {
+  const projet = await createProjet(req.body, {creator: req.creator})
+  const expandedProjet = expandProjet(projet)
+
+  res.status(201).send(expandedProjet)
+}))
+
+export default projetsRouter

--- a/server/routes/report.js
+++ b/server/routes/report.js
@@ -1,0 +1,17 @@
+import express from 'express'
+import w from '../util/w.js'
+
+import {ensureAdmin} from '../auth/middleware.js'
+import {getUpdatedProjets} from '../admin/reports.js'
+
+const reportRoutes = new express.Router()
+
+reportRoutes.get('/', w(ensureAdmin), w(async (req, res) => {
+  const since = new Date(req.query.since)
+  const validDate = Number.isNaN(since.valueOf()) ? new Date('2010-01-01') : since
+  const report = await getUpdatedProjets(validDate)
+
+  res.send(report)
+}))
+
+export default reportRoutes


### PR DESCRIPTION
Cette PR exporte les routes dans des fichiers séparés afin d'alléger le fichier `server/index.js` qui commençait à être long.
Cette modification permettra également de tester les routes.

- Création d’un dossier `routes` 
- Création des fichiers contenant les routes : 
- - `routes/admin.js`
- - `routes/auth.js`
- - `routes/data.js`
- - `routes/projets.js`
- Mise à jour du fichier `server/index.js`

