### PR TITLE
Suppression du fond semi-transparent sur la boite à outils de la carte de suivi

### DIFF
--- a/components/map/map-tool-box.js
+++ b/components/map/map-tool-box.js
@@ -9,7 +9,7 @@ const MapToolBox = ({children}) => {
         position: 'absolute',
         right: '8px',
         top: '110px',
-        backgroundColor: 'rgba(255, 255, 255, .9)',
+        backgroundColor: 'white',
         padding: '3px',
         borderRadius: '5px',
         width: isOpen ? '300px' : '',


### PR DESCRIPTION
Cette PR passe le fond de la boite à outils de carte de suivi en blanc afin d'homogénéiser le visuel avec le composant `Autocomplete`.

### Captures : 
#### Avant : 

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/90e166a1-59b3-486e-9716-8ea06c122544)

#### Après : 

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/c7d6f03f-7f0a-4295-ad2e-50c667477855)
