### PR TITLE
Tests sur les routes de l’API

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-config-xo": "^0.42.0",
     "eslint-config-xo-nextjs": "^4.2.2",
     "mongodb-memory-server": "^8.12.0",
+    "supertest": "^6.3.3",
     "xo": "^0.52.4"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,10 @@
     }
   },
   "ava": {
-    "workerThreads": false
+    "workerThreads": false,
+    "environmentVariables" : {
+      "ADMIN_TOKEN": "toto"
+    }
   },
   "engines": {
     "node": ">= 18"

--- a/server/__tests__/index.js
+++ b/server/__tests__/index.js
@@ -10,6 +10,7 @@ import {handleAuth} from '../auth/middleware.js'
 import errorHandler from '../util/error-handler.js'
 
 import projetsRoutes from '../routes/projets.js'
+import authRoutes from '../routes/auth.js'
 
 import validProjet from '../mock/mock-valid-projet.js'
 import invalidProjet from '../mock/mock-invalid-projet.js'
@@ -39,6 +40,7 @@ const app = express()
 app.use(express.json())
 app.use(w(handleAuth))
 app.use('/projets', projetsRoutes)
+app.use('/', authRoutes)
 app.use(errorHandler)
 
 // Projets routes
@@ -104,4 +106,12 @@ test.serial('Update a projet', async t => {
 
   t.is(status, 200)
   t.is(body.nom, 'Nouveau nom')
+})
+
+// Auth routes
+test.serial('Get role / admin', async t => {
+  const {body} = await request(app).get('/me')
+    .set({Authorization: `Token ${token}`})
+
+  t.is(body.role, 'admin')
 })

--- a/server/__tests__/index.js
+++ b/server/__tests__/index.js
@@ -13,6 +13,7 @@ import projetsRoutes from '../routes/projets.js'
 import authRoutes from '../routes/auth.js'
 import creatorsEmailsRoutes from '../routes/creators-emails.js'
 import administratorsRoutes from '../routes/administrators.js'
+import reportRoutes from '../routes/report.js'
 
 import validProjet from '../mock/mock-valid-projet.js'
 import invalidProjet from '../mock/mock-invalid-projet.js'
@@ -47,6 +48,7 @@ app.use('/projets', projetsRoutes)
 app.use('/', authRoutes)
 app.use('/creators-emails', creatorsEmailsRoutes)
 app.use('/administrators', administratorsRoutes)
+app.use('/report', reportRoutes)
 app.use(errorHandler)
 
 // Projets routes
@@ -251,4 +253,17 @@ test.serial('Delete an administrator', async t => {
 
   t.is(status, 204)
   t.is(body.length, 0)
+})
+
+// Report route
+test.serial('Get admin report', async t => {
+  await request(app).post('/projets')
+    .set({Authorization: `Token ${token}`})
+    .send({...validProjet})
+
+  const {body} = await request(app).get('/report')
+    .set({Authorization: `Token ${token}`})
+
+  t.is(body.length, 1)
+  t.is(body._created, body._updated)
 })

--- a/server/__tests__/index.js
+++ b/server/__tests__/index.js
@@ -1,0 +1,107 @@
+import test from 'ava'
+import {MongoMemoryServer} from 'mongodb-memory-server'
+import express from 'express'
+import request from 'supertest'
+import dotenv from 'dotenv'
+import mongo from '../util/mongo.js'
+import w from '../util/w.js'
+
+import {handleAuth} from '../auth/middleware.js'
+import errorHandler from '../util/error-handler.js'
+
+import projetsRoutes from '../routes/projets.js'
+
+import validProjet from '../mock/mock-valid-projet.js'
+import invalidProjet from '../mock/mock-invalid-projet.js'
+
+dotenv.config()
+
+const token = process.env.ADMIN_TOKEN
+
+let mongod
+
+test.before('Start server', async () => {
+  mongod = await MongoMemoryServer.create()
+  await mongo.connect(mongod.getUri())
+})
+
+test.after.always('Cleanup', async () => {
+  await mongo.disconnect()
+  await mongod.stop()
+})
+
+test.beforeEach('Clean database', async () => {
+  await mongo.db.collection('projets').deleteMany({})
+})
+
+const app = express()
+
+app.use(express.json())
+app.use(w(handleAuth))
+app.use('/projets', projetsRoutes)
+app.use(errorHandler)
+
+// Projets routes
+test.serial('Get projets without admin token', async t => {
+  await mongo.db.collection('projets').insertOne({...validProjet})
+
+  const {body, status} = await request(app).get('/projets')
+
+  t.is(body[0].nom, 'Nom du pcrs')
+  t.is(status, 200)
+  t.truthy(body[0]._id)
+})
+
+test.serial('Create a projet with admin token', async t => {
+  const {body} = await request(app).post('/projets')
+    .set({Authorization: `Token ${token}`})
+    .send(validProjet)
+
+  t.is(body.nom, 'Nom du pcrs')
+  t.is(body.creator, 'admin')
+  t.is(body.etapes.length, 2)
+  t.truthy(body.editorKey)
+})
+
+test.serial('Create a projet with invalid token', async t => {
+  const {body} = await request(app).post('/projets')
+    .set({Authorization: 'Token mauvaistoken'})
+    .send({...validProjet})
+
+  t.is(body.code, 403)
+  t.is(body.message, 'Jeton invalide')
+})
+
+test.serial('Create invalid projet', async t => {
+  const {body} = await request(app).post('/projets')
+    .set({Authorization: `Token ${token}`})
+    .send(invalidProjet)
+
+  t.is(body.code, 400)
+  t.is(body.message, 'Invalid payload')
+  t.is(body.validationErrors.length, 14)
+})
+
+test.serial('Delete a projet', async t => {
+  const projet = await mongo.db.collection('projets').insertOne({...validProjet})
+
+  const {status} = await request(app).delete(`/projets/${projet.insertedId}`)
+    .set({Authorization: `Token ${token}`})
+
+  const deletedProjet = await mongo.db.collection('projets').findOne({_id: projet.insertedId})
+
+  t.is(status, 204)
+  t.truthy(deletedProjet._deleted)
+  t.is(deletedProjet.nom, 'Nom du pcrs')
+})
+
+test.serial('Update a projet', async t => {
+  const projet = await mongo.db.collection('projets').insertOne({...validProjet})
+
+  const {body, status} = await request(app).put(`/projets/${projet.insertedId}`)
+    .set({Authorization: `Token ${token}`})
+    .send({nom: 'Nouveau nom'})
+
+  t.is(status, 200)
+  t.is(body.nom, 'Nouveau nom')
+})

--- a/server/mock/mock-invalid-projet.js
+++ b/server/mock/mock-invalid-projet.js
@@ -1,0 +1,37 @@
+
+/* eslint-disable camelcase */
+/* eslint-disable unicorn/numeric-separators-style */
+
+const invalidProjet = {
+  nom: 'Germonde',
+  regime: 'productio',
+  nature: 'rastèr',
+  livrables: [
+    {
+      nom: 'Images raster',
+      nature: 'geotouff',
+      diffusion: 'flox',
+      licence: 'ouverte_lo',
+      avancement: '12',
+      publication: 'bonjour'
+    }
+  ],
+  acteurs: [
+    {
+      siren: 2000473890,
+      nom: 'FDEA08',
+      telephone: '+33324594528333',
+      role: 'apIc'
+    },
+    {siren: 444608442, nom: 'Eneonze', role: 'financeuse'}
+  ],
+  perimetres: ['departement:00'],
+  etapes: [
+    {statut: 'investigation', date_debut: null},
+    {statut: 'production', date_debut: '1999-02-11'},
+    {statut: 'livre', date_debut: '2010-13-12'}
+  ],
+  subventions: [{nom: 'Participation feder', ntr: 'feder'}]
+}
+
+export default invalidProjet

--- a/server/mock/mock-valid-projet.js
+++ b/server/mock/mock-valid-projet.js
@@ -1,0 +1,52 @@
+/* eslint-disable camelcase */
+/* eslint-disable unicorn/numeric-separators-style */
+
+const validProjet = {
+  nom: 'Nom du pcrs',
+  regime: 'production',
+  nature: 'raster',
+  livrables: [
+    {
+      nom: 'Nom du livrable',
+      nature: 'geotiff',
+      diffusion: 'wmts',
+      licence: 'ouvert_odbl',
+      avancement: 100,
+      crs: 'EPSG:2971',
+      compression: 'Nature untelle'
+    }
+  ],
+  acteurs: [
+    {
+      nom: 'living data',
+      siren: 813600889,
+      role: 'aplc',
+      telephone: '0600000000',
+      finance_part_perc: 50,
+      finance_part_euro: 120000
+    }
+  ],
+  perimetres: [
+    'epci:200039865'
+  ],
+  etapes: [
+    {
+      statut: 'investigation',
+      date_debut: '2023-02-06'
+    },
+    {
+      statut: 'production',
+      date_debut: '2024-02-08'
+    }
+  ],
+  subventions: [
+    {
+      nom: 'Une subvention voilà quoi',
+      nature: 'feder',
+      montant: 100000,
+      echeance: '2024-04-10'
+    }
+  ]
+}
+
+export default validProjet

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,12 +1466,22 @@ arrify@^3.0.0:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-3.0.0.tgz#ccdefb8eaf2a1d2ab0da1ca2ce53118759fd46bc"
   integrity sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==
 
+asap@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
 async-mutex@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.2.tgz#1485eda5bda1b0ec7c8df1ac2e815757ad1831df"
   integrity sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==
   dependencies:
     tslib "^2.3.1"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 ava@^5.2.0:
   version "5.2.0"
@@ -1897,6 +1907,13 @@ color@^4.2.3:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
@@ -1911,6 +1928,11 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
+
+component-emitter@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1976,6 +1998,11 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookiejar@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -2124,6 +2151,11 @@ del@^7.0.0:
     rimraf "^3.0.2"
     slash "^4.0.0"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -2143,6 +2175,14 @@ detect-libc@^2.0.0, detect-libc@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
   integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
+
+dezalgo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
+  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2785,6 +2825,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fast-xml-parser@4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz#5a98c18238d28a57bbdfa9fe4cda01211fff8f4a"
@@ -2896,6 +2941,25 @@ form-data-encoder@^2.1.2:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
   integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+formidable@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.1.2.tgz#fa973a2bec150e4ce7cac15589d7a25fc30ebd89"
+  integrity sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==
+  dependencies:
+    dezalgo "^1.0.4"
+    hexoid "^1.0.0"
+    once "^1.4.0"
+    qs "^6.11.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -3221,6 +3285,11 @@ hash-obj@^4.0.0:
     is-obj "^3.0.0"
     sort-keys "^5.0.0"
     type-fest "^1.0.2"
+
+hexoid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
+  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -4041,7 +4110,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -4064,7 +4133,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -4075,6 +4144,11 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -4954,6 +5028,13 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
+qs@^6.11.0:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
+  integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
+  dependencies:
+    side-channel "^1.0.4"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -5637,6 +5718,22 @@ styled-jsx@5.1.0:
   dependencies:
     client-only "0.0.1"
 
+superagent@^8.0.5:
+  version "8.0.9"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-8.0.9.tgz#2c6fda6fadb40516515f93e9098c0eb1602e0535"
+  integrity sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.4"
+    debug "^4.3.4"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.0"
+    formidable "^2.1.2"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.11.0"
+    semver "^7.3.8"
+
 supercluster@^7.1.5:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.5.tgz#65a6ce4a037a972767740614c19051b64b8be5a3"
@@ -5653,6 +5750,14 @@ supertap@^3.0.1:
     js-yaml "^3.14.1"
     serialize-error "^7.0.1"
     strip-ansi "^7.0.1"
+
+supertest@^6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.3.3.tgz#42f4da199fee656106fd422c094cf6c9578141db"
+  integrity sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^8.0.5"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
Cette PR ajoute des tests sur les routes de l’API.

- Installation de `supertest`
- Ajouts des mocks de projet (valide et invalide)
- Tests sur les routes : 
- - `/projets`
- - `/auth`
- - `/creators-emails`
- - `/administrators`
- - `/report`