### PR TITLE
Corrige le message d’erreur du PUT de les routes `/administrators` et `/creators-emails`

### DIFF
--- a/server/admin/administrators.js
+++ b/server/admin/administrators.js
@@ -63,17 +63,25 @@ export async function updateAdministrator(adminId, update) {
 
   mongo.decorateUpdate(changes)
 
-  const {value} = await mongo.db.collection('administrators').findOneAndUpdate(
-    {_id: adminId},
-    {$set: {...changes}},
-    {returnDocument: 'after'}
-  )
+  try {
+    const {value} = await mongo.db.collection('administrators').findOneAndUpdate(
+      {_id: adminId},
+      {$set: {...changes}},
+      {returnDocument: 'after'}
+    )
 
-  if (!value) {
-    throw createError(404, 'Cet identifiant est introuvable')
+    if (!value) {
+      throw createError(404, 'Cet identifiant est introuvable')
+    }
+
+    return value
+  } catch (error) {
+    if (error.message.includes('E11000')) {
+      throw createError(409, 'Cette adresse courriel est déjà dans la liste.')
+    }
+
+    throw error
   }
-
-  return value
 }
 
 export async function deleteAdministrator(adminId) {

--- a/server/admin/creators-emails.js
+++ b/server/admin/creators-emails.js
@@ -50,17 +50,25 @@ export async function updateCreator(creatorId, update) {
 
   mongo.decorateUpdate(changes)
 
-  const {value} = await mongo.db.collection('creators-emails').findOneAndUpdate(
-    {_id: creatorId},
-    {$set: {...changes}},
-    {returnDocument: 'after'}
-  )
+  try {
+    const {value} = await mongo.db.collection('creators-emails').findOneAndUpdate(
+      {_id: creatorId},
+      {$set: {...changes}},
+      {returnDocument: 'after'}
+    )
 
-  if (!value) {
-    throw createError(404, 'Cette adresse est introuvable')
+    if (!value) {
+      throw createError(404, 'Cette adresse est introuvable')
+    }
+
+    return value
+  } catch (error) {
+    if (error.message.includes('E11000')) {
+      throw createError(409, 'Cette adresse courriel est déjà dans la liste.')
+    }
+
+    throw error
   }
-
-  return value
 }
 
 export async function deleteCreator(creatorId) {


### PR DESCRIPTION
Cette PR corrige le message d’erreur renvoyé par l’API lorsque l’utilisateur veut modifier un administrateur ou un porteur avec une adresse mail déjà présente dans la base de données.

