### PR TITLE
[[QuickFix]] Corrige la recherche par EPCI de la calculatrice

### DIFF
--- a/pages/calculatrice.js
+++ b/pages/calculatrice.js
@@ -67,7 +67,7 @@ const Calculatrice = () => {
     const foundPerimetreName = foundPerimetres.find(result => result.code === code).nom
 
     try {
-      const response = await fetch(`${API_BASE_URL}/calculator/territory-area/${territoryType}s:${code}`)
+      const response = await fetch(`${API_BASE_URL}/calculator/territory-area/${territoryType}${territoryType === 'epci' ? '' : 's'}:${code}`)
       const area = await response.json()
 
       if (!areas.some(area => area.code === code)) {


### PR DESCRIPTION
Sur la page `/calculatrice`, la recherche par territoire de type "EPCI" fait planter le site.

Le problème venait de l'appel à l'API : 
Lorsque l'URL est construite, nous ajoutons un "S" au type de territoire afin d'appeler l'index correct. 
Or, l'index pour les EPCI est bien "epci" et non "epciS". ([ref](https://github.com/openpcrs/pcrs.beta.gouv.fr/blob/c0542b225724bcc5102e755194ed10481c66db3e/lib/territoires.js#L50))

Cette PR ajoute une condition afin d'éviter d'ajouter un "s" lorsque le territoire est de type epci.

EDIT : 
Cette PR est une correction rapide pour contourner un problème plus compliqué à régler.
Une issue a été ouverte [ici](https://github.com/openpcrs/pcrs.beta.gouv.fr/issues/285)
