### PR TITLE
Ajout de la vérification de l’adresse email lors de l'édition d’un porteur de projet

### DIFF
--- a/server/admin/__tests__/administrators.js
+++ b/server/admin/__tests__/administrators.js
@@ -97,6 +97,16 @@ test.serial('Update administrator / invalid mail', async t => {
   await t.throwsAsync(async () => updateAdministrator(administrator.insertedId, {email: 'mailPasValide'}))
 })
 
+test.serial('Update administrator / empty mail', async t => {
+  const administrator = await mongo.db.collection('administrators').insertOne({
+    nom: 'Administrateur',
+    email: 'administrateur@mail.com',
+    token: nanoid()
+  })
+
+  await t.throwsAsync(async () => updateAdministrator(administrator.insertedId, {email: ''}))
+})
+
 test.serial('Delete administrator', async t => {
   const admin1 = await mongo.db.collection('administrators').insertOne({
     nom: 'Administrateur',

--- a/server/admin/__tests__/administrators.js
+++ b/server/admin/__tests__/administrators.js
@@ -107,6 +107,16 @@ test.serial('Update administrator / empty mail', async t => {
   await t.throwsAsync(async () => updateAdministrator(administrator.insertedId, {email: ''}))
 })
 
+test.serial('Update administrator / email null', async t => {
+  const administrator = await mongo.db.collection('administrators').insertOne({
+    nom: 'Administrateur',
+    email: 'administrateur@mail.com',
+    token: nanoid()
+  })
+
+  await t.throwsAsync(async () => updateAdministrator(administrator.insertedId, {email: null}))
+})
+
 test.serial('Delete administrator', async t => {
   const admin1 = await mongo.db.collection('administrators').insertOne({
     nom: 'Administrateur',

--- a/server/admin/__tests__/creators-emails.js
+++ b/server/admin/__tests__/creators-emails.js
@@ -87,6 +87,15 @@ test.serial('Update creator / empty mail', async t => {
   await t.throwsAsync(async () => updateCreator(creator.insertedId, {email: ''}))
 })
 
+test.serial('Update creator / email null', async t => {
+  const creator = await mongo.db.collection('creators-emails').insertOne({
+    nom: 'Créateur',
+    email: 'createur@mail.com'
+  })
+
+  await t.throwsAsync(async () => updateCreator(creator.insertedId, {email: null}))
+})
+
 test.serial('Delete creator', async t => {
   const creator = await mongo.db.collection('creators-emails').insertOne({
     nom: 'Créateur',

--- a/server/admin/__tests__/creators-emails.js
+++ b/server/admin/__tests__/creators-emails.js
@@ -1,0 +1,108 @@
+import test from 'ava'
+import {MongoMemoryServer} from 'mongodb-memory-server'
+import mongo from '../../util/mongo.js'
+import {addCreator, deleteCreator, getCreators, updateCreator} from '../creators-emails.js'
+
+let mongod
+
+test.before('Start server', async () => {
+  mongod = await MongoMemoryServer.create()
+  await mongo.connect(mongod.getUri())
+})
+
+test.after.always('cleanup', async () => {
+  await mongo.disconnect()
+  await mongod.stop()
+})
+
+test.beforeEach('Clean database', async () => {
+  await mongo.db.collection('creators-emails').deleteMany()
+})
+
+test.serial('Create creator: valid', async t => {
+  const creator = await addCreator({
+    nom: 'Createur',
+    email: 'createur@mail.com'
+  })
+
+  t.is(creator.nom, 'Createur')
+  t.is(creator.email, 'createur@mail.com')
+  t.is(creator._created, creator._updated)
+})
+
+test.serial('Create creator: email not valid', async t => {
+  await t.throwsAsync(async () => addCreator({
+    nom: 'Createur',
+    email: 'create.com'
+  }), {message: 'Cette adresse courriel est invalide'})
+})
+
+test.serial('Get creators', async t => {
+  await mongo.db.collection('creators-emails').insertOne({
+    nom: 'Createur',
+    email: 'createur@mail.com'
+  })
+
+  await mongo.db.collection('creators-emails').insertOne({
+    nom: 'Createur2',
+    email: 'createur2@mail.com'
+  })
+
+  const creators = await getCreators()
+
+  t.is(creators.length, 2)
+  t.truthy(creators[0]._id)
+})
+
+test.serial('Update creator', async t => {
+  const creator = await mongo.db.collection('creators-emails').insertOne({
+    nom: 'Createur',
+    email: 'createur@mail.com'
+  })
+
+  const updatedCreator = await updateCreator(
+    creator.insertedId,
+    {nom: 'Créatrice'}
+  )
+
+  t.is(updatedCreator.nom, 'Créatrice')
+  t.truthy(updatedCreator._updated)
+})
+
+test.serial('Update creator / invalid mail', async t => {
+  const creator = await mongo.db.collection('creators-emails').insertOne({
+    nom: 'Créateur',
+    email: 'createur@mail.com'
+  })
+
+  await t.throwsAsync(async () => updateCreator(creator.insertedId, {email: 'email@pasvalide'}))
+})
+
+test.serial('Update creator / empty mail', async t => {
+  const creator = await mongo.db.collection('creators-emails').insertOne({
+    nom: 'Créateur',
+    email: 'createur@mail.com'
+  })
+
+  await t.throwsAsync(async () => updateCreator(creator.insertedId, {email: ''}))
+})
+
+test.serial('Delete creator', async t => {
+  const creator = await mongo.db.collection('creators-emails').insertOne({
+    nom: 'Créateur',
+    email: 'createur@mail.com'
+  })
+
+  await mongo.db.collection('creators-emails').insertOne({
+    nom: 'Créatrice',
+    email: 'creatrice@mail.com'
+  })
+
+  const deletedCreator = await deleteCreator(creator.insertedId)
+  const allCreators = await mongo.db.collection('creators-emails').find().toArray()
+
+  t.true(deletedCreator)
+  t.falsy(allCreators.find(a => a.nom === 'Créateur'))
+  t.truthy(allCreators.find(a => a.nom === 'Créatrice'))
+  t.is(allCreators.length, 1)
+})

--- a/server/admin/administrators.js
+++ b/server/admin/administrators.js
@@ -57,7 +57,7 @@ export async function updateAdministrator(adminId, update) {
   const changes = pick(update, ['email', 'nom'])
   adminId = mongo.parseObjectId(adminId)
 
-  if (changes.email && !validateEmail(changes.email)) {
+  if (changes.email !== undefined && !validateEmail(changes.email)) {
     throw createError(400, 'Cette adresse courriel est invalide')
   }
 

--- a/server/admin/creators-emails.js
+++ b/server/admin/creators-emails.js
@@ -44,9 +44,12 @@ export async function addCreator(creator) {
 }
 
 export async function updateCreator(creatorId, update) {
+  const changes = pick(update, ['email', 'nom'])
   creatorId = mongo.parseObjectId(creatorId)
 
-  const changes = pick(update, ['email', 'nom'])
+  if (changes.email && !validateEmail(changes.email)) {
+    throw createError(400, 'Cette adresse courriel est invalide')
+  }
 
   mongo.decorateUpdate(changes)
 

--- a/server/admin/creators-emails.js
+++ b/server/admin/creators-emails.js
@@ -47,7 +47,7 @@ export async function updateCreator(creatorId, update) {
   const changes = pick(update, ['email', 'nom'])
   creatorId = mongo.parseObjectId(creatorId)
 
-  if (changes.email && !validateEmail(changes.email)) {
+  if (changes.email !== undefined && !validateEmail(changes.email)) {
     throw createError(400, 'Cette adresse courriel est invalide')
   }
 


### PR DESCRIPTION
En testant la PR #283, j'ai remarqué que l’API ne vérifie pas la validité de l’adresse mail lors de l’édition de celle-ci.

Cette PR ajoute cette vérification de la même façon que pour les administrateurs.

