### PR TITLE
Corrige une erreur 500 sur les liens d’édition

### DIFF
--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -1,6 +1,6 @@
 import {maxBy} from 'lodash-es'
 
-const URL = process.env.NEXT_PUBLIC_URL || 'https://pcrs.beta.gouv.fr'
+const API_URL = process.env.NEXT_PUBLIC_URL || 'https://pcrs.beta.gouv.fr'
 
 async function request(url, options) {
   const res = await fetch(`${URL}${url}`, options)

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -3,7 +3,7 @@ import {maxBy} from 'lodash-es'
 const API_URL = process.env.NEXT_PUBLIC_URL || 'https://pcrs.beta.gouv.fr'
 
 async function request(url, options) {
-  const res = await fetch(`${URL}${url}`, options)
+  const res = await fetch(`${API_URL}${url}`, options)
 
   if (res.status === 204) {
     return res

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -1,7 +1,9 @@
 import {maxBy} from 'lodash-es'
 
+const URL = process.env.NEXT_PUBLIC_URL || 'https://pcrs.beta.gouv.fr'
+
 async function request(url, options) {
-  const res = await fetch(`${url}`, options)
+  const res = await fetch(`${URL}${url}`, options)
 
   if (res.status === 204) {
     return res


### PR DESCRIPTION
Suite à une mise à jour de la gestion des variables d’environnement, une erreur 500 était lancée lorsque l’utilisateur utilisait le lien d’édition d’un projet.

Cette PR enlève un `getInitialProps` pour utiliser un simple `useEffect` et corrige une URL relative.

