### PR TITLE
Ajout d'un chargement à la page /suivi-formulaire

### DIFF
--- a/pages/formulaire-suivi.js
+++ b/pages/formulaire-suivi.js
@@ -1,5 +1,4 @@
 import {useContext, useEffect, useState} from 'react'
-import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import Image from 'next/image'
 
@@ -15,11 +14,12 @@ import SuiviForm from '@/components/suivi-form/index.js'
 import Loader from '@/components/loader.js'
 
 const FormulaireSuivi = () => {
-  const router = useRouter()
   const {token, userRole, isTokenRecovering} = useContext(AuthentificationContext)
   const [project, setProject] = useState()
   const [errorCode, setErrorCode] = useState()
   const [isLoading, setIsLoading] = useState(true)
+
+  const router = useRouter()
   const {id, editcode} = router.query
 
   useEffect(() => {
@@ -105,19 +105,6 @@ const FormulaireSuivi = () => {
         `}</style>
     </Page>
   )
-}
-
-FormulaireSuivi.propTypes = {
-  project: PropTypes.object,
-  editCode: PropTypes.string,
-  isNotFound: PropTypes.bool,
-  isForbidden: PropTypes.bool
-}
-
-FormulaireSuivi.defaultProps = {
-  editCode: null,
-  isNotFound: false,
-  isForbidden: false
 }
 
 export default FormulaireSuivi

--- a/pages/formulaire-suivi.js
+++ b/pages/formulaire-suivi.js
@@ -12,22 +12,27 @@ import Page from '@/layouts/main.js'
 
 import Button from '@/components/button.js'
 import SuiviForm from '@/components/suivi-form/index.js'
+import Loader from '@/components/loader.js'
 
 const FormulaireSuivi = () => {
   const router = useRouter()
   const {token, userRole, isTokenRecovering} = useContext(AuthentificationContext)
   const [project, setProject] = useState()
   const [errorCode, setErrorCode] = useState()
+  const [isLoading, setIsLoading] = useState(true)
   const {id, editcode} = router.query
 
   useEffect(() => {
     async function getProjectData() {
+      setIsLoading(true)
       try {
         const project = await getProject(id)
         setProject(project)
       } catch {
         setErrorCode(404)
       }
+
+      setIsLoading(false)
     }
 
     if (id) {
@@ -36,6 +41,8 @@ const FormulaireSuivi = () => {
       }
 
       getProjectData()
+    } else {
+      setIsLoading(false)
     }
   }, [id, editcode])
 
@@ -72,9 +79,13 @@ const FormulaireSuivi = () => {
     )
   }
 
-  if (project) {
-    return (
-      <Page>
+  return (
+    <Page>
+      {isLoading ? (
+        <div className='loading-container'>
+          <Loader />
+        </div>
+      ) : (
         <SuiviForm
           userRole={userRole}
           token={token}
@@ -82,9 +93,18 @@ const FormulaireSuivi = () => {
           isTokenRecovering={isTokenRecovering}
           {...project}
         />
-      </Page>
-    )
-  }
+      )}
+
+      <style jsx>{`
+        .loading-container {
+          display: flex;
+          height: 100%;
+          justify-content: center;
+          align-items: center;
+        }
+        `}</style>
+    </Page>
+  )
 }
 
 FormulaireSuivi.propTypes = {


### PR DESCRIPTION
## Contexte
Depuis la dernière PR, il n'est plus possible de créer un formulaire. Une page vierge est renvoyé quand aucun projet n’est trouvé, empêchant la création d’un nouveau.


## Correction
Un chargement a été ajouté à la page, le temps que le projet soit récupéré s'il est passé en paramètre. Le formulaire est renvoyé même sans projet afin de pouvoir faire une création.