### PR TITLE
Vérification de la validité du code d'édition

### DIFF
--- a/pages/formulaire-suivi.js
+++ b/pages/formulaire-suivi.js
@@ -16,7 +16,7 @@ import Loader from '@/components/loader.js'
 const FormulaireSuivi = () => {
   const {token, userRole, isTokenRecovering} = useContext(AuthentificationContext)
   const [project, setProject] = useState()
-  const [errorCode, setErrorCode] = useState()
+  const [errorMessage, setErrorMessage] = useState()
   const [isLoading, setIsLoading] = useState(true)
 
   const router = useRouter()
@@ -28,8 +28,8 @@ const FormulaireSuivi = () => {
       try {
         const project = await getProject(id, editcode)
         setProject(project)
-      } catch {
-        setErrorCode(404)
+      } catch (error) {
+        setErrorMessage(error.message)
       }
 
       setIsLoading(false)
@@ -37,7 +37,7 @@ const FormulaireSuivi = () => {
 
     if (id) {
       if (!editcode) {
-        setErrorCode(403)
+        setErrorMessage('Jeton manquant')
       }
 
       getProjectData()
@@ -46,12 +46,12 @@ const FormulaireSuivi = () => {
     }
   }, [id, editcode])
 
-  if (errorCode) {
+  if (errorMessage) {
     return (
       <Page>
         <div className='not-found-wrapper fr-p-5w'>
           <Image
-            src={`/images/illustrations/${editcode ? 'pcrs-beta_illustration' : '403'}.png`}
+            src='/images/illustrations/403.png'
             height={456}
             width={986}
             alt=''
@@ -63,8 +63,7 @@ const FormulaireSuivi = () => {
           />
 
           <div className='not-found-explain fr-pt-8w'>
-            <h1 className='fr-my-1w'>{errorCode}</h1>
-            <p><b className='fr-mt-3w'>Vous n’avez pas les droits pour éditer ce projet. Veuillez demander un lien d’édition à un administrateur</b></p>
+            <p><b className='fr-mt-3w fr-text--xl'>{errorMessage}</b></p>
             <Button label='Retour à la page d’accueil' href='/'><span className='fr-icon-home-4-line' aria-hidden='true' />&nbsp;Retour au début de la rue</Button>
           </div>
         </div>

--- a/pages/formulaire-suivi.js
+++ b/pages/formulaire-suivi.js
@@ -26,7 +26,7 @@ const FormulaireSuivi = () => {
     async function getProjectData() {
       setIsLoading(true)
       try {
-        const project = await getProject(id)
+        const project = await getProject(id, editcode)
         setProject(project)
       } catch {
         setErrorCode(404)


### PR DESCRIPTION
### **Problème**
Jusqu'à présent, la validité du code d'édition passé en `query` dans la page du formulaire de suivi n'était pas vérifiée. De ce fait, un code d'édition périmé permettait encore d'accéder à l'édition du formulaire

Fix #295 

-----------------------------------
### **Résolution**

- Ajout du code d'édition en tant que `token` à la fonction `getProject`. La vérification s'effectue ainsi en amont et une erreur `403` est automatiquement retournée en cas d'échec d'authentification dû à la non-correspondance du code entré et du code rattaché au projet.
- Le message d'erreur donnant la raison du blocage au formulaire est affiché au lieu du code afin d'ajouter de la compréhension et facilité la gestion des codes d'erreur en front

<img width="1440" alt="Capture d’écran 2023-09-26 à 15 41 54" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/5c0729f8-142f-4c48-80d7-6b509fa59418">
