### PR TITLE
Correction de la réédition du code d'édition

### DIFF
--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -132,7 +132,7 @@ export async function deleteAdministrator(adminId, token) {
 }
 
 export async function resetEditCode(projetId, token) {
-  const options = buildOptions({method: 'POST', token})
+  const options = buildOptions({method: 'GET', token})
 
   return request(`/projets/${projetId}/renew-editor-key`, options)
 }


### PR DESCRIPTION
La méthode de la fonction `resetEditCode` était erronée, menant à une erreur `404` au moment de la réédition du code d'édition.

### **Solution** : 
Changer la méthode `POST` en `GET`