### PR TITLE
[FIX] "section_activite_principale" peut être nul 

### DIFF
--- a/components/suivi-form/acteurs/actors-autocomplete-input.js
+++ b/components/suivi-form/acteurs/actors-autocomplete-input.js
@@ -58,7 +58,7 @@ const ActorsAutocompleteInput = ({isRequired, inputValue, inputError, onValueCha
       results={foundEtablissements}
       isLoading={isLoading}
       errorMessage={errorMessage || inputError}
-      renderItem={item => `${item.nom_complet} - ${secteursActivites[item.section_activite_principale]}`}
+      renderItem={item => `${item.nom_complet} - ${secteursActivites[item.section_activite_principale] || 'N/A'}`}
       onInputChange={onValueChange}
       onSelectValue={onSelectValue}
     />

--- a/components/suivi-form/acteurs/actors-autocomplete-input.js
+++ b/components/suivi-form/acteurs/actors-autocomplete-input.js
@@ -58,7 +58,7 @@ const ActorsAutocompleteInput = ({isRequired, inputValue, inputError, onValueCha
       results={foundEtablissements}
       isLoading={isLoading}
       errorMessage={errorMessage || inputError}
-      renderItem={item => `${item.nom_complet} - ${secteursActivites[item.section_activite_principale] || 'N/A'}`}
+      renderItem={item => `${item.nom_complet} ${secteursActivites[item.section_activite_principale] ? `- ${secteursActivites[item.section_activite_principale]}` : ''}`}
       onInputChange={onValueChange}
       onSelectValue={onSelectValue}
     />


### PR DESCRIPTION
Le composant `ActorsAutocompleteInput` permet d'afficher les acteurs ainsi que leur secteur d'activité principale (`section_activite_principale`). Or cette activité peut être non définie et affiche donc `undefined`

### **Solution :** 
Afficher la valeur "N/A" en cas de valeur nulle afin d'avertir l'utilisateur que cette information n'a pas été renseignée

<img width="463" alt="Capture d’écran 2023-09-29 à 18 12 04" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/66621960/1a7d7689-a9de-4ab1-bb38-39663c79d42c">

Close  #306
