### PR TITLE
Ajout d'un composant onglet

### DIFF
--- a/components/ui/tab.js
+++ b/components/ui/tab.js
@@ -1,0 +1,55 @@
+import PropTypes from 'prop-types'
+
+const Tab = ({activeTab, tabs, icon, children, handleActiveTab}) => (
+  <div className='fr-tabs'>
+    <ul className='fr-tabs__list' role='tablist'>
+      {tabs.map((tab, index) => {
+        const defaultTab = !activeTab && index === 0
+
+        return (
+          <li key={tab.label} role='presentation'>
+            <button
+              disabled={tab?.isDisabled}
+              type='button'
+              className={`fr-tabs__tab ${icon ? `fr-icon-${icon}` : ''} fr-tabs__tab--icon-left`}
+              role='tab'
+              aria-selected={defaultTab || (activeTab === tab.label ? 'true' : 'false')}
+              onClick={() => handleActiveTab(tab.label)}
+            >
+              {tab.label}
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+
+    <div className='content-wrapper fr-tabs__panel fr-tabs__panel--selected' role='tabpanel'>
+      {children}
+    </div>
+
+    <style jsx>{`
+      .content-wrapper {
+        border: 1px solid #dddddd;
+      }
+    `}</style>
+  </div>
+)
+
+Tab.propTypes = {
+  activeTab: PropTypes.string,
+  icon: PropTypes.string,
+  tabs: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    isDisabled: PropTypes.bool
+  })).isRequired,
+  handleActiveTab: PropTypes.func.isRequired,
+  children: PropTypes.node
+}
+
+Tab.defaultProps = {
+  activeTab: null,
+  icon: null,
+  children: null
+}
+
+export default Tab


### PR DESCRIPTION
Le composant `<Tab />` s'appuie sur le composant `Onglet - Tab` du DSFR.
Le chargement du fichier contenant les scripts du DSFR n'étant pour le moment pas possible sur un projet Nextjs, le comportement est reproduit et adapté dans le composant `<Tab />`.  

Props reçues : 
`activeTab` : <_string_> => Onglet sélectionné. Permet de désigner l'onglet actif.
`tabs`  : <_collection_> => Liste d'onglets. L'objet se présente comme suit : `{label: 'Foo', isDisabled: true}` (`isDisabled` est non-requis)
`icon` : <_string_> => Désigne l'icône pouvant être affiché dans l'onglet (non-requis)
`children` : <_node_> => Contenu affiché lors de la sélection de l'onglet
`handleActiveTab` : <_function_> => Gère la sélection des onglets