### PR TITLE
Reprise du formulaire de périmètres 

### DIFF
--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -227,7 +227,6 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
               perimetres={projetPerimetres}
               handlePerimetres={setProjetPerimetres}
               hasMissingData={hasMissingItemsOnValidation}
-              onRequiredFormOpen={setIsRequiredFormOpen}
             />
           </div>
 

--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -28,7 +28,6 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
   const [validationMessage, setValidationMessage] = useState(null)
   const [errorMessage, setErrorMessage] = useState(null)
   const [errors, setErrors] = useState([])
-  const [isRequiredFormOpen, setIsRequiredFormOpen] = useState(false)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const [editedProjectId, setEditedProjectId] = useState(null)
@@ -50,10 +49,10 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
   const handleDeleteModalOpen = () => setIsDeleteModalOpen(!isDeleteModalOpen)
 
   useEffect(() => {
-    if (!hasMissingRequiredItems && !isRequiredFormOpen) {
+    if (!hasMissingRequiredItems) {
       setErrorMessage(null)
     }
-  }, [hasMissingRequiredItems, isRequiredFormOpen])
+  }, [hasMissingRequiredItems])
 
   const handleAuthentificationModal = () => router.push('/suivi-pcrs')
   const handleModal = () => router.push('/suivi-pcrs')
@@ -77,10 +76,6 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
     }
 
     try {
-      if (isRequiredFormOpen) {
-        return setErrorMessage('Veuiller valider ou annuler le livrable, l’acteur ou le périmètre en cours d’ajout.')
-      }
-
       if (hasMissingRequiredItems) {
         setHasMissingItemsOnValidation(true)
         handleScrollToError()

--- a/components/suivi-form/perimetres/index.js
+++ b/components/suivi-form/perimetres/index.js
@@ -1,11 +1,21 @@
 import PropTypes from 'prop-types'
 
+import {useState} from 'react'
 import colors from '@/styles/colors.js'
 
 import Perimetre from '@/components/suivi-form/perimetres/perimetre.js'
 import PerimetreForm from '@/components/suivi-form/perimetres/perimetre-form.js'
+import Button from '@/components/button.js'
 
 const Perimetres = ({perimetres, hasMissingData, handlePerimetres}) => {
+  const hasPerimetres = perimetres.length > 0
+  const [perimetre, setPerimetre] = useState(hasPerimetres ? null : {})
+
+  const handlePerimetre = ({type, code}) => {
+    handlePerimetres([...perimetres, `${type}:${code}`])
+    setPerimetre(null)
+  }
+
   const onDelete = index => {
     handlePerimetres(current => current.filter((_, i) => index !== i))
   }
@@ -15,23 +25,14 @@ const Perimetres = ({perimetres, hasMissingData, handlePerimetres}) => {
       <h3 className='fr-h5 fr-m-0'>Périmètres *</h3>
       <hr className='fr-my-3w' />
 
-      {(hasMissingData && perimetres.length === 0) && (
-        <div className='fr-error-text fr-mt-1w'>Au moins un périmètre doit être ajouté</div>
-      )}
-
       <div className='fr-notice fr-notice--info'>
         <div className='fr-mx-2w fr-notice__body'>
           <p>les référentiels INSEE les plus à jour qui ne tiennent pas compte des territoires fusionnés il y a plus d’un an </p>
         </div>
       </div>
 
-      <PerimetreForm
-        perimetres={perimetres}
-        handlePerimetres={handlePerimetres}
-      />
-
-      {perimetres.length > 0 && (
-        <hr className='edit-separator fr-my-3w' />
+      {(hasMissingData && perimetres.length === 0) && (
+        <div className='fr-error-text fr-mt-1w'>Au moins un périmètre doit être ajouté</div>
       )}
 
       <div className='fr-grid-row fr-mt-2w'>
@@ -47,6 +48,29 @@ const Perimetres = ({perimetres, hasMissingData, handlePerimetres}) => {
           )
         })}
       </div>
+
+      {hasPerimetres && (
+        <hr className='edit-separator fr-my-3w' />
+      )}
+
+      {perimetre ? (
+        <PerimetreForm
+          perimetres={perimetres}
+          onCancel={hasPerimetres ? () => setPerimetre(null) : null}
+          onSubmit={handlePerimetre}
+        />
+      ) : (
+        <div className='fr-mt-3w'>
+          <Button
+            label='Ajouter un périmètre'
+            icon='add-circle-fill'
+            iconSide='left'
+            onClick={() => setPerimetre({})}
+          >
+            Ajouter un périmètre
+          </Button>
+        </div>
+      )}
 
       <style jsx>{`
         hr {

--- a/components/suivi-form/perimetres/index.js
+++ b/components/suivi-form/perimetres/index.js
@@ -53,7 +53,7 @@ const Perimetres = ({perimetres, hasMissingData, handlePerimetres}) => {
         <hr className='edit-separator fr-my-3w' />
       )}
 
-      {perimetre ? (
+      {perimetre || !hasPerimetres ? (
         <PerimetreForm
           perimetres={perimetres}
           onCancel={hasPerimetres ? () => setPerimetre(null) : null}

--- a/components/suivi-form/perimetres/index.js
+++ b/components/suivi-form/perimetres/index.js
@@ -5,7 +5,7 @@ import colors from '@/styles/colors.js'
 import Perimetre from '@/components/suivi-form/perimetres/perimetre.js'
 import PerimetreForm from '@/components/suivi-form/perimetres/perimetre-form.js'
 
-const Perimetres = ({perimetres, hasMissingData, handlePerimetres, onRequiredFormOpen}) => {
+const Perimetres = ({perimetres, hasMissingData, handlePerimetres}) => {
   const onDelete = index => {
     handlePerimetres(current => current.filter((_, i) => index !== i))
   }
@@ -28,7 +28,6 @@ const Perimetres = ({perimetres, hasMissingData, handlePerimetres, onRequiredFor
       <PerimetreForm
         perimetres={perimetres}
         handlePerimetres={handlePerimetres}
-        onRequiredFormOpen={onRequiredFormOpen}
       />
 
       {perimetres.length > 0 && (
@@ -64,8 +63,7 @@ const Perimetres = ({perimetres, hasMissingData, handlePerimetres, onRequiredFor
 Perimetres.propTypes = {
   perimetres: PropTypes.array.isRequired,
   hasMissingData: PropTypes.bool,
-  handlePerimetres: PropTypes.func.isRequired,
-  onRequiredFormOpen: PropTypes.func.isRequired
+  handlePerimetres: PropTypes.func.isRequired
 }
 
 Perimetres.defaultProps = {

--- a/components/suivi-form/perimetres/index.js
+++ b/components/suivi-form/perimetres/index.js
@@ -1,31 +1,13 @@
-import {useState} from 'react'
 import PropTypes from 'prop-types'
 
 import colors from '@/styles/colors.js'
 
 import Perimetre from '@/components/suivi-form/perimetres/perimetre.js'
 import PerimetreForm from '@/components/suivi-form/perimetres/perimetre-form.js'
-import Button from '@/components/button.js'
 
 const Perimetres = ({perimetres, hasMissingData, handlePerimetres, onRequiredFormOpen}) => {
-  const [isAdding, setIsAdding] = useState(false)
-  const [isEditing, setIsEditing] = useState(false)
-  const [updatingPerimetreIndex, setUpdatingPerimetreIndex] = useState()
-
-  const isFormOpen = isAdding || isEditing
-
   const onDelete = index => {
     handlePerimetres(current => current.filter((_, i) => index !== i))
-    setIsAdding(false)
-    setIsEditing(false)
-  }
-
-  const perimetreAsObject = perimetre => {
-    const perimetreAsArray = perimetre.split(':')
-    const perimetreType = perimetreAsArray[0]
-    const perimetreCode = perimetreAsArray[1]
-
-    return {perimetreType, perimetreCode}
   }
 
   return (
@@ -43,81 +25,34 @@ const Perimetres = ({perimetres, hasMissingData, handlePerimetres, onRequiredFor
         </div>
       </div>
 
+      <PerimetreForm
+        perimetres={perimetres}
+        handlePerimetres={handlePerimetres}
+        onRequiredFormOpen={onRequiredFormOpen}
+      />
+
+      {perimetres.length > 0 && (
+        <hr className='edit-separator fr-my-3w' />
+      )}
+
       <div className='fr-grid-row fr-mt-2w'>
-        {perimetres.map((perimetre, idx) => (
-          <div key={perimetre} className={updatingPerimetreIndex === idx ? 'fr-col-12' : ''}>
+        {perimetres.map((perimetre, index) => {
+          const [type, code] = perimetre.split(':')
+          return (
             <Perimetre
-              perimetre={perimetre}
-              perimetreAsObject={perimetreAsObject(perimetre)}
-              isFormOpen={isFormOpen}
-              handleUpdate={() => {
-                setIsEditing(true)
-                setUpdatingPerimetreIndex(idx)
-              }}
-              handleDelete={() => onDelete(idx)}
+              key={perimetre}
+              type={type}
+              code={code}
+              handleDelete={() => onDelete(index)}
             />
-
-            {updatingPerimetreIndex === idx && (
-              <div>
-                <PerimetreForm
-                  perimetreAsObject={perimetreAsObject}
-                  updatingPerimetreIdx={updatingPerimetreIndex}
-                  handleUpdatingPerimetreIdx={setUpdatingPerimetreIndex}
-                  handleAdding={setIsAdding}
-                  handleEditing={setIsEditing}
-                  perimetres={perimetres}
-                  handlePerimetres={handlePerimetres}
-                  isEditing={isEditing}
-                  onRequiredFormOpen={onRequiredFormOpen}
-                />
-
-                <hr className='edit-separator fr-my-3w' />
-              </div>
-            )}
-          </div>
-        )
-        )}
+          )
+        })}
       </div>
 
-      {isAdding && (
-        <PerimetreForm
-          perimetreAsObject={perimetreAsObject}
-          updatingPerimetreIdx={updatingPerimetreIndex}
-          handleUpdatingPerimetreIdx={setUpdatingPerimetreIndex}
-          handleAdding={setIsAdding}
-          handleEditing={setIsEditing}
-          perimetres={perimetres}
-          handlePerimetres={handlePerimetres}
-          isEditing={isEditing}
-          onRequiredFormOpen={onRequiredFormOpen}
-        />
-      )}
-
-      {!isAdding && !isEditing && (
-        <div className='fr-mt-3w'>
-          <Button
-            label='Ajouter un périmètre'
-            icon='add-circle-fill'
-            iconSide='left'
-            onClick={() => {
-              onRequiredFormOpen(true)
-              setIsAdding(true)
-            }}
-          >
-            Ajouter un périmètre
-          </Button>
-        </div>
-      )}
-
       <style jsx>{`
-        .editing-perimetre {
-          flex: 1;
-        }
-
         hr {
           border-top: 3px solid ${colors.grey850};
         }
-
         .edit-separator {
           border-top: 2px solid ${colors.blueFrance850};
         }

--- a/components/suivi-form/perimetres/perimetre-form.js
+++ b/components/suivi-form/perimetres/perimetre-form.js
@@ -12,7 +12,7 @@ import SelectInput from '@/components/select-input.js'
 import Button from '@/components/button.js'
 import AutocompleteInput from '@/components/autocomplete-input.js'
 
-const PerimetreForm = ({perimetres, handlePerimetres}) => {
+const PerimetreForm = ({perimetres, onCancel, onSubmit}) => {
   const [type, setType, typeError] = useInput({initialValue: 'epci', isRequired: true})
   const [code, setCode] = useState(null)
   const searchValueInput = useInput({isRequired: true})
@@ -50,8 +50,7 @@ const PerimetreForm = ({perimetres, handlePerimetres}) => {
   }, [type, code])
 
   const handleSubmit = () => {
-    handlePerimetres([...perimetres, `${type}:${code}`])
-    onReset()
+    onSubmit({type, code})
   }
 
   const fetchPerimetres = useRef(debounce(async (nom, type, signal) => {
@@ -152,7 +151,7 @@ const PerimetreForm = ({perimetres, handlePerimetres}) => {
           </div>
         )}
 
-        <div className='fr-grid-row'>
+        <div className='fr-grid-row fr-mt-3w'>
           <Button
             label='Valider l’ajout du périmètre'
             icon='checkbox-circle-fill'
@@ -161,8 +160,21 @@ const PerimetreForm = ({perimetres, handlePerimetres}) => {
           >
             Ajouter
           </Button>
+
+          {onCancel && (
+            <div className='fr-pl-3w'>
+              <Button
+                label='Annuler l’ajout du livrable'
+                buttonStyle='tertiary'
+                onClick={onCancel}
+              >
+                Annuler
+              </Button>
+            </div>
+          )}
         </div>
       </div>
+
       {errorMessage && <p id='text-input-error-desc-error' className='fr-error-text'>{errorMessage}</p>}
     </div>
   )
@@ -170,7 +182,8 @@ const PerimetreForm = ({perimetres, handlePerimetres}) => {
 
 PerimetreForm.propTypes = {
   perimetres: PropTypes.array.isRequired,
-  handlePerimetres: PropTypes.func.isRequired
+  onCancel: PropTypes.func,
+  onSubmit: PropTypes.func.isRequired
 }
 
 export default PerimetreForm

--- a/components/suivi-form/perimetres/perimetre.js
+++ b/components/suivi-form/perimetres/perimetre.js
@@ -6,18 +6,15 @@ import colors from '@/styles/colors.js'
 import {getPerimetersByCode} from '@/lib/decoupage-administratif-api.js'
 import Loader from '@/components/loader.js'
 
-const Perimetre = ({perimetre, perimetreAsObject, isFormOpen, handleUpdate, handleDelete}) => {
+const Perimetre = ({type, code, handleDelete}) => {
   const [isLoading, setIsLoading] = useState(true)
-  const [type, setType] = useState(null)
   const [nom, setNom] = useState(null)
-  const {perimetreType, perimetreCode} = perimetreAsObject
 
   useEffect(() => {
     const getPerimetreData = async () => {
       try {
-        const perimetreData = await getPerimetersByCode(perimetreCode, perimetreType)
+        const perimetreData = await getPerimetersByCode(code, type)
 
-        setType(perimetreType)
         setNom(perimetreData.nom)
       } catch (error) {
         throw new Error(error)
@@ -27,10 +24,10 @@ const Perimetre = ({perimetre, perimetreAsObject, isFormOpen, handleUpdate, hand
     }
 
     getPerimetreData()
-  }, [perimetre, perimetreType, perimetreCode])
+  }, [type, code])
 
   return (
-    <div className={`fr-grid-row fr-mr-1w fr-px-2w fr-py-1w fr-my-1w card-container ${isFormOpen ? 'card-disable' : ''}`}>
+    <div className='fr-grid-row fr-mr-1w fr-px-2w fr-py-1w fr-my-1w card-container'>
       {isLoading ? (
         <div className='fr-grid-row fr-grid-row--center'>
           <Loader size='small' />
@@ -44,15 +41,6 @@ const Perimetre = ({perimetre, perimetreAsObject, isFormOpen, handleUpdate, hand
           </div>
 
           <div className='fr-pl-6w'>
-            <button
-              type='button'
-              className='update-button fr-mr-1w fr-col-5'
-              aria-label='Modifier le périmètre'
-              onClick={handleUpdate}
-            >
-              <span className='fr-icon-edit-line' aria-hidden='true' />
-            </button>
-
             <button
               type='button'
               aria-label='Supprimer le périmètre'
@@ -71,26 +59,14 @@ const Perimetre = ({perimetre, perimetreAsObject, isFormOpen, handleUpdate, hand
           border-radius: 4px;
         }
 
-        .card-disable {
-          opacity: 30%;
-          pointer-events: none;
-        }
-
         .label {
           font-weight: bold;
           color: ${colors.blueFranceSun113};
         }
 
-        .update-button, .delete-button {
+        .delete-button {
           text-decoration: underline;
           width: fit-content;
-        }
-
-        .update-button {
-          color: ${colors.blueFranceSun113};
-        }
-
-        .delete-button {
           color: ${colors.error425};
         }
       `}</style>
@@ -99,10 +75,8 @@ const Perimetre = ({perimetre, perimetreAsObject, isFormOpen, handleUpdate, hand
 }
 
 Perimetre.propTypes = {
-  perimetre: PropTypes.string.isRequired,
-  perimetreAsObject: PropTypes.object.isRequired,
-  isFormOpen: PropTypes.bool.isRequired,
-  handleUpdate: PropTypes.func.isRequired,
+  type: PropTypes.string.isRequired,
+  code: PropTypes.string.isRequired,
   handleDelete: PropTypes.func.isRequired
 }
 

--- a/hooks/input.js
+++ b/hooks/input.js
@@ -1,11 +1,19 @@
-import {useState, useEffect} from 'react'
+import {useState, useEffect, useRef, useCallback} from 'react'
 
 import PropTypes from 'prop-types'
 
 export const useInput = ({initialValue, checkValue, isRequired}) => {
   const [input, setInput] = useState(initialValue || '')
   const [error, setError] = useState(null)
-  const [isValueValid, setIsValueValid] = useState(true)
+  const [isValueValid, setIsValueValid] = useState()
+
+  const hasInputBeenUpdated = useRef(Boolean(initialValue))
+
+  useEffect(() => {
+    if (input !== '') {
+      hasInputBeenUpdated.current = true
+    }
+  }, [input])
 
   useEffect(() => {
     setError(null)
@@ -19,12 +27,19 @@ export const useInput = ({initialValue, checkValue, isRequired}) => {
     }
 
     // Handle errors messages if required input empty
-    if (!input && isRequired) {
+    if (!input && isRequired && hasInputBeenUpdated.current) {
       setError('Ce champs est requis')
     }
   }, [input, isRequired, checkValue])
 
-  return [input, setInput, error, setIsValueValid, isValueValid]
+  const resetInput = useCallback(() => {
+    setError(null)
+    setInput(initialValue || '')
+    setIsValueValid()
+    hasInputBeenUpdated.current = false
+  }, [initialValue])
+
+  return [input, setInput, error, setIsValueValid, isValueValid, resetInput]
 }
 
 useInput.propTypes = {


### PR DESCRIPTION
## Contexte
Le code des composants du formulaire de périmètres souffre de quelques erreurs de conception et est assez complexe à maintenir.

## Évolutions
Cette PR corrige les différents problèmes du composant et supprime l'édition pour simplifier son usage et son code.

Le fonctionnement de ce formulaire a également été modifié, afin de rester affiché et permettre l'ajout de plusieurs périmètres les uns à la suite des autres.

## Démonstration
https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/7040549/26eadd41-5696-4617-b313-0b0556dc6c82

## Autre modification
Le `hook` `useInput` peut maintenant détecter si un champ a été utilisé pour ne pas renvoyer de message d'erreur si le champ est requis et vide à l'initialisation. De plus, une méthode de "reset" a été ajouté afin de réinitialiser complètement l'input à la demande.