### PR TITLE
Correction de la validation d’erreur d'un champ nombre

### DIFF
--- a/components/number-input.js
+++ b/components/number-input.js
@@ -100,8 +100,6 @@ NumberInput.defaultProps = {
   placeholder: null,
   errorMessage: null,
   description: null,
-  min: null,
-  max: null,
   isRequired: false,
   isDisabled: false,
   onFocus: null,


### PR DESCRIPTION
## Contexte
Lorsque l'on utilise un champ `<NumberInput />` alors que `min` ou `max` n'est pas défini, alors la validation du champ ne se fait pas correctement est l'erreur `La valeur doit être comprise entre 0 et null` s’affiche.

## Résumé
Cette erreur s’affiche, car la valeur `null` est donnée par défaut à `min` et `max` via `defaultProps` lorsqu'ils ne sont pas définis. Or la méthode `handleRangeError` s'attend à avoir des `undefined`.


Cette PR retire l'attribution de valeur pas défaut à `min` et `max` dans `<NumberInput/>`.