### PR TITLE
Reprise du formulaire des subventions

### DIFF
--- a/components/number-input.js
+++ b/components/number-input.js
@@ -5,7 +5,6 @@ import {handleRangeError} from './suivi-form/acteurs/utils/error-handlers.js'
 const NumberInput = ({
   label,
   value,
-  type,
   min,
   max,
   ariaLabel,
@@ -30,12 +29,8 @@ const NumberInput = ({
   }, [value, min, max, errorMessage])
 
   useEffect(() => {
-    if (inputError) {
-      setIsValueValid(false)
-    } else {
-      setIsValueValid(true)
-    }
-  }, [value, inputError, setIsValueValid])
+    setIsValueValid(!inputError)
+  }, [inputError, setIsValueValid])
 
   return (
     <div className={`fr-input-group fr-input-group--${inputState}`}>
@@ -46,7 +41,7 @@ const NumberInput = ({
 
       <input
         {...props}
-        type={type}
+        type='number'
         required={isRequired}
         className={`fr-input fr-input--${inputState}`}
         value={value}
@@ -95,7 +90,6 @@ NumberInput.propTypes = {
 NumberInput.defaultProps = {
   label: '',
   value: '',
-  type: 'text',
   ariaLabel: '',
   placeholder: null,
   errorMessage: null,

--- a/components/suivi-form/subventions/index.js
+++ b/components/suivi-form/subventions/index.js
@@ -1,81 +1,88 @@
-import {useState} from 'react'
+import {useCallback, useState} from 'react'
 import PropTypes from 'prop-types'
 import {uniqueId} from 'lodash-es'
 
 import colors from '@/styles/colors.js'
+
+import {normalizeSring} from '@/lib/string.js'
 
 import SubventionCard from '@/components/suivi-form/subventions/subvention-card.js'
 import SubventionForm from '@/components/suivi-form/subventions/subvention-form.js'
 import Button from '@/components/button.js'
 
 const Subventions = ({subventions, handleSubventions}) => {
-  const [isAdding, setIsAdding] = useState(false)
-  const [isEditing, setIsEditing] = useState(false)
-  const [updatingSubvIndex, setUpdatingSubvIndex] = useState(null)
-
-  const isFormOpen = isAdding || isEditing
+  const [editedSubvention, setEditedSubvention] = useState(null)
 
   const onDelete = index => {
     handleSubventions(current => current.filter((_, i) => index !== i))
-    setIsAdding(false)
-    setIsEditing(false)
+    setEditedSubvention(null)
   }
+
+  const handleSubvention = useCallback(subvention => {
+    if (editedSubvention && editedSubvention.index >= 0) {
+      handleSubventions(prevSubventions => {
+        const subventionsCopy = [...prevSubventions]
+        subventionsCopy[editedSubvention.index] = subvention
+        return subventionsCopy
+      })
+    } else {
+      handleSubventions([...subventions, subvention])
+    }
+
+    setEditedSubvention(null)
+  }, [editedSubvention, subventions, handleSubventions])
+
+  const isSubventionExisting = useCallback(nom => {
+    const _subventions = (typeof editedSubvention?.index === 'undefined')
+      ? subventions
+      : subventions.filter((a, idx) => idx !== editedSubvention.index) // Filter subvention being edited
+    return _subventions.some(subvention => normalizeSring(nom) === normalizeSring(subvention.nom))
+  }, [editedSubvention, subventions])
 
   return (
     <div className='fr-mt-8w'>
       <h3 className='fr-h5'>Subventions</h3>
       <hr className='fr-my-3w' />
 
-      {subventions.map((subvention, idx) => (
+      {subventions.map((subvention, index) => (
         <div key={uniqueId()}>
-          <SubventionCard
-            {...subvention}
-            isFormOpen={isFormOpen}
-            handleSubventions={handleSubventions}
-            handleEdition={() => {
-              setUpdatingSubvIndex(idx)
-              setIsEditing(true)
-            }}
-            handleDelete={() => onDelete(idx)}
-          />
-
-          {updatingSubvIndex === idx && (
+          {editedSubvention && editedSubvention.index === index ? (
             <div>
               <SubventionForm
-                subventions={subventions}
-                handleSubventions={handleSubventions}
-                updatingSubvIdx={updatingSubvIndex}
-                isEditing={isEditing}
-                isAdding={isAdding}
-                handleEditing={setIsEditing}
-                handleAdding={setIsAdding}
-                handleUpdatingSubvIdx={setUpdatingSubvIndex}
+                initialValues={editedSubvention.subvention}
+                isSubventionExisting={isSubventionExisting}
+                onCancel={() => setEditedSubvention(null)}
+                onSubmit={handleSubvention}
               />
               <hr className='edit-separator fr-my-3w' />
             </div>
+          ) : (
+            <SubventionCard
+              {...subvention}
+              isDisabled={Boolean(editedSubvention)}
+              handleSubventions={handleSubventions}
+              handleEdition={() => setEditedSubvention({subvention, index})}
+              handleDelete={() => onDelete(index)}
+            />
           )}
         </div>
       ))}
 
-      {isAdding && (
+      {editedSubvention && !editedSubvention.index && (
         <SubventionForm
-          subventions={subventions}
-          handleSubventions={handleSubventions}
-          updatingSubvIdx={updatingSubvIndex}
-          isEditing={isEditing}
-          isAdding={isAdding}
-          handleEditing={setIsEditing}
-          handleAdding={setIsAdding}
-          handleUpdatingSubvIdx={setUpdatingSubvIndex}
+          initialValues={editedSubvention}
+          isSubventionExisting={isSubventionExisting}
+          onCancel={() => setEditedSubvention(null)}
+          onSubmit={handleSubvention}
         />
       )}
 
-      {!isAdding && !isEditing && (
+      {!editedSubvention && (
         <Button
           label='Ajouter une subvention'
           icon='add-circle-fill'
           iconSide='left'
-          onClick={() => setIsAdding(true)}
+          onClick={() => setEditedSubvention({})}
         >
           Ajouter une subvention
         </Button>

--- a/components/suivi-form/subventions/index.js
+++ b/components/suivi-form/subventions/index.js
@@ -68,7 +68,7 @@ const Subventions = ({subventions, handleSubventions}) => {
         </div>
       ))}
 
-      {editedSubvention && !editedSubvention.index && (
+      {editedSubvention && editedSubvention.index === undefined && (
         <SubventionForm
           initialValues={editedSubvention}
           isSubventionExisting={isSubventionExisting}

--- a/components/suivi-form/subventions/subvention-card.js
+++ b/components/suivi-form/subventions/subvention-card.js
@@ -3,6 +3,8 @@ import {formatDate} from '@/lib/date-utils.js'
 
 import colors from '@/styles/colors.js'
 
+import {formatNumber} from '@/lib/string.js'
+
 import {getNatures} from '@/components/suivi-form/subventions/utils/select-options.js'
 
 const SubventionCard = ({nom, montant, echeance, nature, isDisabled, handleDelete, handleEdition}) => (
@@ -25,7 +27,7 @@ const SubventionCard = ({nom, montant, echeance, nature, isDisabled, handleDelet
       <div className='fr-grid-row fr-col-12 fr-col-xl-6'>
         <div className='fr-grid-row fr-col-12 fr-col-md-6 fr-p-1w'>
           <div className=' label fr-col-12 fr-text--lg fr-m-0'>Montant</div>
-          <div className='fr-m-0 fr-col-12 fr-text--sm'>{montant || 'N/A'}</div>
+          <div className='fr-m-0 fr-col-12 fr-text--sm'>{montant ? `${formatNumber(montant)} €` : 'N/A'}</div>
         </div>
 
         <div className='fr-grid-row col-12 fr-col-md-6 fr-p-1w'>

--- a/components/suivi-form/subventions/subvention-card.js
+++ b/components/suivi-form/subventions/subvention-card.js
@@ -5,8 +5,8 @@ import colors from '@/styles/colors.js'
 
 import {getNatures} from '@/components/suivi-form/subventions/utils/select-options.js'
 
-const SubventionCard = ({nom, montant, echeance, nature, isFormOpen, handleDelete, handleEdition}) => (
-  <div className={`fr-grid-row fr-p-2w fr-my-3w card-container ${isFormOpen ? 'card-disable' : ''}`}>
+const SubventionCard = ({nom, montant, echeance, nature, isDisabled, handleDelete, handleEdition}) => (
+  <div className={`fr-grid-row fr-p-2w fr-my-3w card-container ${isDisabled ? 'card-disable' : ''}`}>
     <div className='fr-grid-row fr-col-10'>
       <div className='fr-grid-row fr-col-12 fr-col-xl-6'>
         <div className='fr-grid-row fr-grid-row--middle fr-col-12 fr-col-md-6 fr-p-1w'>
@@ -35,25 +35,27 @@ const SubventionCard = ({nom, montant, echeance, nature, isFormOpen, handleDelet
       </div>
     </div>
 
-    <div className='fr-grid-row fr-col-12 fr-col-md-2 fr-mt-3w fr-mt-md-0 fr-pl-md-1w fr-grid-row--middle '>
-      <button
-        type='button'
-        className='fr-grid-row fr-col-md-12 fr-col-lg-6 update-button'
-        onClick={handleEdition}
-      >
-        <span className='fr-icon-edit-line fr-col-12' aria-hidden='true' />
-        <div className='fr-col-12'>Modifier</div>
-      </button>
+    {!isDisabled && (
+      <div className='fr-grid-row fr-col-12 fr-col-md-2 fr-mt-3w fr-mt-md-0 fr-pl-md-1w fr-grid-row--middle '>
+        <button
+          type='button'
+          className='fr-grid-row fr-col-md-12 fr-col-lg-6 update-button'
+          onClick={handleEdition}
+        >
+          <span className='fr-icon-edit-line fr-col-12' aria-hidden='true' />
+          <div className='fr-col-12'>Modifier</div>
+        </button>
 
-      <button
-        type='button'
-        className='fr-grid-row fr-col-md-12 fr-col-lg-6 fr-pl-1w delete-button'
-        onClick={handleDelete}
-      >
-        <span className='fr-icon-delete-line fr-col-12' aria-hidden='true' />
-        <div className='fr-col-12'>Supprimer</div>
-      </button>
-    </div>
+        <button
+          type='button'
+          className='fr-grid-row fr-col-md-12 fr-col-lg-6 fr-pl-1w delete-button'
+          onClick={handleDelete}
+        >
+          <span className='fr-icon-delete-line fr-col-12' aria-hidden='true' />
+          <div className='fr-col-12'>Supprimer</div>
+        </button>
+      </div>
+    )}
 
     <style jsx>{`
       .card-container {
@@ -96,7 +98,7 @@ SubventionCard.propTypes = {
   montant: PropTypes.number,
   echeance: PropTypes.string,
   nature: PropTypes.string.isRequired,
-  isFormOpen: PropTypes.bool.isRequired,
+  isDisabled: PropTypes.bool.isRequired,
   handleEdition: PropTypes.func.isRequired,
   handleDelete: PropTypes.func.isRequired
 }

--- a/lib/string.js
+++ b/lib/string.js
@@ -4,6 +4,11 @@ export function normalizeSort(string) {
   return deburr(string.toLowerCase())
 }
 
+export function normalizeSring(string) {
+  // Remove accents with lodash.deburr, lowercase, remove leading and trailing spaces, and replace multiple spaces with a single space
+  return deburr(string).toLowerCase().trim().replace(/\s+/g, ' ')
+}
+
 export function stripNonNumericCharacters(string) {
   return string.replace(/\D/g, '')
 }

--- a/lib/string.js
+++ b/lib/string.js
@@ -21,3 +21,10 @@ export function formatInternationalPhone(phone) {
 
   return formatted
 }
+
+export function formatNumber(number) {
+  const numStr = number.toString()
+
+  // Use a regular expression to add a space every three digits
+  return numStr.replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
+}


### PR DESCRIPTION
## Contexte
Le code des composants du formulaire des subventions souffre de quelques erreurs de conception et est assez complexe à maintenir.

## Évolutions
Cette PR corrige :
- les différents problèmes du composant (notamment la gestion compliquée de l'ajout et la modification d'une subvention)
- Format le montant en euros

## Autre modification
Le composant `<NumberInput/>` force désormais le type d'input à `number`, puisque c'est le rôle de ce composant.