### PR TITLE
Mises à jour du script de migration vers le modèle v0.4

### DIFF
--- a/backend/lib/projets-validator.js
+++ b/backend/lib/projets-validator.js
@@ -322,7 +322,9 @@ const livrablesSchemaUpdate = Joi.object().keys({
     'any.only': 'Ce type de stockage n’est pas valide'
   }),
   stockage_params: Joi.object()
-}).unknown()
+}).messages({
+  'object.unknown': 'Une clé de l’objet est invalide'
+})
 
 const subventionsSchemaUpdate = Joi.object().keys({
   nom: Joi.string().messages({

--- a/backend/lib/projets-validator.js
+++ b/backend/lib/projets-validator.js
@@ -322,9 +322,7 @@ const livrablesSchemaUpdate = Joi.object().keys({
     'any.only': 'Ce type de stockage n’est pas valide'
   }),
   stockage_params: Joi.object()
-}).messages({
-  'object.unknown': 'Une clé de l’objet est invalide'
-})
+}).unknown()
 
 const subventionsSchemaUpdate = Joi.object().keys({
   nom: Joi.string().messages({

--- a/scripts/migration-v04.js
+++ b/scripts/migration-v04.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable camelcase */
 /* eslint-disable no-await-in-loop */
 
 import mongo from '../backend/util/mongo.js'
@@ -6,6 +7,24 @@ import mongo from '../backend/util/mongo.js'
 await mongo.connect()
 
 const projets = await mongo.db.collection('projets').find({}).toArray()
+
+function updateEtapes(etapes) {
+  if (etapes.some(e => e.statut === 'prod_en_cours')) {
+    if (!etapes.some(e => e.statut === 'convention_signee')) {
+      etapes.splice(1, 0, {
+        statut: 'convention_signee',
+        date_debut: null
+      })
+    }
+
+    if (!etapes.some(e => e.statut === 'marche_public_en_cours')) {
+      etapes.splice(2, 0, {
+        statut: 'marche_public_en_cours',
+        date_debut: null
+      })
+    }
+  }
+}
 
 for (const projet of projets) {
   const updatedEtapes = projet.etapes.map(etape => {
@@ -32,6 +51,8 @@ for (const projet of projets) {
 
     return etape
   })
+
+  updateEtapes(updatedEtapes)
 
   await mongo.db.collection('projets').updateOne(
     {_id: projet._id},

--- a/scripts/migration-v04.js
+++ b/scripts/migration-v04.js
@@ -27,6 +27,14 @@ function updateEtapes(etapes) {
 }
 
 for (const projet of projets) {
+  const updatedLivrables = projet.livrables.map(livrable => {
+    delete livrable.compression
+    delete livrable.crs
+    delete livrable.publication
+
+    return livrable
+  })
+
   const updatedEtapes = projet.etapes.map(etape => {
     if (etape.statut === 'production') {
       return {
@@ -56,7 +64,12 @@ for (const projet of projets) {
 
   await mongo.db.collection('projets').updateOne(
     {_id: projet._id},
-    {$set: {etapes: updatedEtapes}}
+    {$set:
+      {
+        etapes: updatedEtapes,
+        livrables: updatedLivrables
+      }
+    }
   )
 }
 


### PR DESCRIPTION
## Problèmes : 

La migration ne prend pas en compte les nouveaux champs `prod_en_cours` et `convention_signee`.

Les champs `crs`, `compression`, `publication` ne sont plus pris en charge.

## Solutions : 

Cette PR ajoute une fonction qui ajoute les champs `prod_en_cours` et `convention_signee` aux statuts des étapes comportant un champ `prod_en_cours`.

Elle ajoute également un champ `date_debut` initialisé à `null`.

La suppression des champs non utilisés a été ajoutée.

Une tolérance sur les champs inconnus a été ajoutée afin de ne pas casser la compatibilité avec le modèle précédent.

