### PR TITLE
Ajout d’une route pour récupére un jeton de téléchargement de tuiles

### DIFF
--- a/backend/lib/api-scanner.js
+++ b/backend/lib/api-scanner.js
@@ -15,3 +15,12 @@ export async function attachStorage({type, params}) {
 
   return {_id}
 }
+
+export async function askDownloadToken({stockageId}) {
+  const {token} = await got.post(`${SCANNER_URL}/storages/${stockageId}/generate-download-token`, {
+    headers: {authorization: `Token ${SCANNER_ADMIN_TOKEN}`}
+  }).json()
+
+  return {token}
+}
+

--- a/backend/lib/api-scanner.js
+++ b/backend/lib/api-scanner.js
@@ -21,6 +21,6 @@ export async function askDownloadToken({stockageId}) {
     headers: {authorization: `Token ${SCANNER_ADMIN_TOKEN}`}
   }).json()
 
-  return {token}
+  return token
 }
 

--- a/backend/routes/projets.js
+++ b/backend/routes/projets.js
@@ -42,7 +42,7 @@ projetsRoutes.post('/:projetId/stockages/:stockageId/generate-download-token', w
     throw createError(403, 'Impossible d’utiliser le téléchargement sur ce stockage')
   }
 
-  const {token} = await askDownloadToken({stockageId})
+  const token = await askDownloadToken({stockageId})
 
   res.send({token})
 }))

--- a/backend/routes/projets.js
+++ b/backend/routes/projets.js
@@ -4,6 +4,7 @@ import w from '../util/w.js'
 
 import {ensureCreator, ensureAdmin, ensureProjectEditor} from '../auth/middleware.js'
 import {getProjets, expandProjet, filterSensitiveFields, createProjet, getProjet, getProjetsGeojson, renewEditorKey, deleteProjet, updateProjet} from '../lib/models/projets.js'
+import {askDownloadToken} from '../lib/api-scanner.js'
 
 const projetsRoutes = new express.Router()
 
@@ -28,6 +29,22 @@ projetsRoutes.get('/:projetId/renew-editor-key', w(ensureAdmin), w(async (req, r
   const updatedProjet = await renewEditorKey(req.projet)
 
   res.status(200).send(updatedProjet)
+}))
+
+projetsRoutes.post('/:projetId/stockages/:stockageId/generate-download-token', w(ensureAdmin), w(async (req, res) => {
+  const {projet} = req
+  const {stockageId} = req.params
+  const isDownloadable = projet.livrables.find(l => (
+    l.stockage_id === stockageId && l.stockage_telechargement
+  ))
+
+  if (!isDownloadable) {
+    throw createError(403, 'Impossible d’utiliser le téléchargement sur ce stockage')
+  }
+
+  const {token} = await askDownloadToken({stockageId})
+
+  res.send({token})
 }))
 
 projetsRoutes.route('/:projetId')


### PR DESCRIPTION
Cette PR ajoute une route permettant de récupérer un jeton autorisant à télécharger une tuile depuis un stockage publique.

- Ajout d’une fonction pour demander un jeton au scanner
- Ajout d’une route qui vérifie que le téléchargement est possible puis renvoie le jeton.
