### PR TITLE
Supprime la vérification du jeton d’administration pour le téléchargement

### DIFF
--- a/backend/routes/projets.js
+++ b/backend/routes/projets.js
@@ -31,7 +31,7 @@ projetsRoutes.get('/:projetId/renew-editor-key', w(ensureAdmin), w(async (req, r
   res.status(200).send(updatedProjet)
 }))
 
-projetsRoutes.post('/:projetId/stockages/:stockageId/generate-download-token', w(ensureAdmin), w(async (req, res) => {
+projetsRoutes.post('/:projetId/stockages/:stockageId/generate-download-token', w(async (req, res) => {
   const {projet} = req
   const {stockageId} = req.params
   const isDownloadable = projet.livrables.find(l => (


### PR DESCRIPTION
Cette PR supprime la vérification du token d’administrateur lors de l’appel à la route permettant de récupérer un jeton pour télécharger une tuile.

