### PR TITLE
Téléchargement des données issues d'un stockage

### DIFF
--- a/components/projet/index.js
+++ b/components/projet/index.js
@@ -48,7 +48,7 @@ const ProjetInfos = ({project}) => {
           </div>
 
           <div className='fr-col-12 fr-mt-6w'>
-            <Livrables livrables={livrables} />
+            <Livrables projectId={_id} livrables={livrables} />
           </div>
 
           <div className='fr-col-12 fr-mt-6w'>

--- a/components/projet/livrables-section.js
+++ b/components/projet/livrables-section.js
@@ -8,27 +8,26 @@ import {LIVRABLE_NATURES} from '@/lib/utils/projet.js'
 import {livrableRenderItem} from '@/components/projet/list-render-items.js'
 import SelectInput from '@/components/select-input.js'
 
-const LivrablesSection = ({livrables}) => {
+const LivrablesSection = ({projectId, livrables}) => {
   const [selectedLivrableIdx, setSelectedLivrableIdx] = useState(0)
 
   const orderedLivrablesByPublication = sortBy(livrables, livrable =>
     livrable.date_livraison ? new Date(livrable.date_livraison) : 0
   )
 
-  const stockageId = orderedLivrablesByPublication[selectedLivrableIdx]?.stockage_id
-  const isSelectedLivrablePublic = orderedLivrablesByPublication[selectedLivrableIdx]?.stockage_public
-
   const livrablesOptions = orderedLivrablesByPublication.map((item, idx) => ({
     label: `${item.nom} - ${LIVRABLE_NATURES[item.nature].label}`,
     value: idx
   }))
+
+  const livrable = orderedLivrablesByPublication[selectedLivrableIdx]
 
   return (
     <div>
       <h3 className='fr-text--lead fr-mt-5w fr-mb-3w'>Livrables : {livrables.length}</h3>
       <div>
         <SelectInput
-          value={selectedLivrableIdx.toString()}
+          value={livrable.stockage_id}
           label='Sélectionner un livrable'
           options={livrablesOptions}
           isDisabled={livrables.length === 1}
@@ -38,9 +37,14 @@ const LivrablesSection = ({livrables}) => {
         <div>
           {livrableRenderItem(orderedLivrablesByPublication[selectedLivrableIdx])}
 
-          {stockageId && (
+          {livrable && (
             <div className='stockage-preview'>
-              <StockagePreview stockageId={stockageId} isStockagePublic={isSelectedLivrablePublic} />
+              <StockagePreview
+                projectId={projectId}
+                stockageId={livrable.stockage_id}
+                isStockagePublic={livrable.stockage_public}
+                isDownloadable={livrable.stockage_telechargement}
+              />
             </div>
           )}
         </div>
@@ -57,6 +61,7 @@ const LivrablesSection = ({livrables}) => {
 }
 
 LivrablesSection.propTypes = {
+  projectId: PropTypes.string,
   livrables: PropTypes.array.isRequired
 }
 

--- a/components/projet/scanned-data.js
+++ b/components/projet/scanned-data.js
@@ -10,7 +10,7 @@ import colors from '@/styles/colors.js'
 import CenteredSpinnder from '@/components/centered-spinner.js'
 import ScannerMap from '@/components/projet/scanner-map.js'
 
-const ScannedData = ({data, geojson, stockageId, handleStorage, handleErrorMessages, errorMessages}) => {
+const ScannedData = ({data, downloadToken, geojson, stockageId, handleStorage, handleErrorMessages, errorMessages}) => {
   const {lastError, result} = data
   const [isLoading, setIsLoading] = useState(true)
 
@@ -78,7 +78,7 @@ const ScannedData = ({data, geojson, stockageId, handleStorage, handleErrorMessa
               <p id='text-input-error-desc-error' className='fr-error-text'>{errorMessages.geojsonFetchError}</p>
             ) : (
               <div className='map-wrapper'>
-                <ScannerMap geojson={geojson} />
+                <ScannerMap geojson={geojson} downloadToken={downloadToken} />
               </div>
             )}
 
@@ -107,6 +107,7 @@ const ScannedData = ({data, geojson, stockageId, handleStorage, handleErrorMessa
 ScannedData.propTypes = {
   data: PropTypes.object,
   geojson: PropTypes.object,
+  downloadToken: PropTypes.string,
   errorMessages: PropTypes.object.isRequired,
   stockageId: PropTypes.string.isRequired,
   handleStorage: PropTypes.func.isRequired,

--- a/components/projet/stockage-preview.js
+++ b/components/projet/stockage-preview.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import {useEffect, useState} from 'react'
 
 import {getStockage} from '@/lib/pcrs-scanner-api.js'
+import {getStorageDownloadToken} from '@/lib/suivi-pcrs.js'
 
 import colors from '@/styles/colors.js'
 
@@ -9,9 +10,10 @@ import CenteredSpinnder from '@/components/centered-spinner.js'
 import StockageData from '@/components/projet/stockage-data.js'
 import ScannedData from '@/components/projet/scanned-data.js'
 
-const StockagePreview = ({stockageId, isStockagePublic}) => {
+const StockagePreview = ({projectId, stockageId, isStockagePublic, isDownloadable}) => {
   const [stockage, setStockage] = useState()
   const [errorMessages, setErrorMessages] = useState({geojsonFetchError: null, dataFetchError: null})
+  const [downloadToken, setDownloadToken] = useState()
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -31,6 +33,21 @@ const StockagePreview = ({stockageId, isStockagePublic}) => {
 
     fetchStockage()
   }, [stockageId])
+
+  useEffect(() => {
+    async function getDownloadToken() {
+      try {
+        const {token} = await getStorageDownloadToken(projectId, stockage.data._id)
+        setDownloadToken(token)
+      } catch (error) {
+        console.error(`Fail to get download token : ${error}`)
+      }
+    }
+
+    if (stockage && isDownloadable) {
+      getDownloadToken()
+    }
+  }, [projectId, stockage, isDownloadable])
 
   return (
     <div className='fr-grid-row'>
@@ -53,6 +70,7 @@ const StockagePreview = ({stockageId, isStockagePublic}) => {
               errorMessages={errorMessages}
               {...stockage}
               stockageId={stockageId}
+              downloadToken={downloadToken}
               handleStorage={setStockage}
               handleErrorMessages={setErrorMessages}
             />
@@ -77,8 +95,10 @@ const StockagePreview = ({stockageId, isStockagePublic}) => {
 }
 
 StockagePreview.propTypes = {
+  projectId: PropTypes.string.isRequired,
   stockageId: PropTypes.string.isRequired,
-  isStockagePublic: PropTypes.bool
+  isStockagePublic: PropTypes.bool,
+  isDownloadable: PropTypes.bool.isRequired
 }
 
 StockagePreview.defaultProps = {

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -135,6 +135,11 @@ export async function resetEditCode(projetId, token) {
   return request(`/projets/${projetId}/renew-editor-key`, options)
 }
 
+export async function getStorageDownloadToken(projetId, stockageId) {
+  const options = {method: 'POST'}
+  return request(`/projets/${projetId}/stockages/${stockageId}/generate-download-token`, options)
+}
+
 export async function getAllChanges(token) {
   const options = buildOptions({method: 'GET', token})
 


### PR DESCRIPTION
## Évolution
Cette PR ajout la possibilité de télécharger les données d'une dalle issue du stockage d’un livrable.

Lorsque la donnée est disponible, il est possible de cliquer sur une tuile afin de la télécharger. Une bulle d’information a été ajoutée au popup qui s'affiche au survol.

## Pré-visualisation
![Capture d’écran 2023-10-23 à 21 10 36](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/7040549/1a022201-d788-429c-a426-aef9af9ddc14)

## Autre modification
Le middleware `ensureIsAdmin` a été retiré de la route `/:projetId/stockages/:stockageId/generate-download-token` afin de la rendre accessible à tous.