### PR TITLE
Ajout des méta de la page projet

### DIFF
--- a/pages/projet/[id].js
+++ b/pages/projet/[id].js
@@ -47,7 +47,7 @@ const Projet = ({id}) => {
 
   if (errorMessage) {
     return (
-      <Page title={`Projet ${project.nom}`} description='Page contenant les informations relatives à un projets'>
+      <Page title='Erreur sur la page' description={errorMessage}>
         <div className='not-found-wrapper fr-p-5w'>
           <Image
             src='/images/illustrations/403.png'
@@ -78,7 +78,7 @@ const Projet = ({id}) => {
   }
 
   return (
-    <Page>
+    <Page title={project?.nom ? `Projet ${project.nom}` : null} description='Page contenant les informations relatives à un projets'>
       {isLoading ? (
         <CenteredSpinner />
       ) : (


### PR DESCRIPTION
Les metas de la page se trouvait sur la page d'erreur renvoyée.

- Modification des erreurs de la page renvoyant l'erreur
- Ajout des metas de la page projet