### PR TITLE
Mise à jour des labels utilisés pour le stockage

### DIFF
--- a/components/suivi-form/livrables/stockage-card.js
+++ b/components/suivi-form/livrables/stockage-card.js
@@ -18,7 +18,7 @@ const StockageCard = ({type, params, generalSettings, handleDelete}) => {
           </div>
 
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
-            <div className='label fr-col-12'>{STOCKAGE_PARAMS.url.label}</div>
+            <div className='label fr-col-12'>URL</div>
             <div className='fr-col-12 fr-text--sm fr-m-0'>{url}</div>
           </div>
 

--- a/components/suivi-form/livrables/stockage-card.js
+++ b/components/suivi-form/livrables/stockage-card.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 
 import colors from '@/styles/colors.js'
+import {STOCKAGE_PARAMS} from '@/lib/utils/projet.js'
 
 const StockageCard = ({type, params, generalSettings, handleDelete}) => {
   const url = type === 'http' ? params.url : `${params.host}${params.port ? `:${params.port}` : ''}${params.startPath || ''}`
@@ -17,17 +18,17 @@ const StockageCard = ({type, params, generalSettings, handleDelete}) => {
           </div>
 
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
-            <div className='label fr-col-12'>URL</div>
+            <div className='label fr-col-12'>{STOCKAGE_PARAMS.url.label}</div>
             <div className='fr-col-12 fr-text--sm fr-m-0'>{url}</div>
           </div>
 
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
-            <div className='label fr-col-12'>Nom d’utilisateur</div>
+            <div className='label fr-col-12'>{STOCKAGE_PARAMS.username.label}</div>
             <div className='fr-col-12 fr-text--sm fr-m-0'>{params.username || 'N/A'}</div>
           </div>
 
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
-            <div className='label fr-col-12'>Mot de passe</div>
+            <div className='label fr-col-12'>{STOCKAGE_PARAMS.password.label}</div>
             <div className='fr-col-12 fr-text--sm fr-m-0'>{params.password ? params.password.replace(/./g, '*') : 'N/A'}</div>
           </div>
         </div>

--- a/components/suivi-form/livrables/stockage-form/ftp-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/ftp-params-inputs.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types'
 
+import {STOCKAGE_PARAMS} from '@/lib/utils/projet.js'
+
 import TextInput from '@/components/text-input.js'
 import NumberInput from '@/components/number-input.js'
 
@@ -14,7 +16,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
         <TextInput
           isRequired
           name='host'
-          label='Nom d’hôte'
+          label={STOCKAGE_PARAMS.host.label}
           placeholder='ftp3.ign.fr'
           description='Nom d’hôte du serveur ou adresse IP'
           value={stockageParams.host || ''}
@@ -26,7 +28,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
         <div className='fr-mt-6w'>
           <NumberInput
             name='port'
-            label='Port'
+            label={STOCKAGE_PARAMS.port.label}
             placeholder=''
             description='Port d’écoute du service FTP'
             value={stockageParams.port || ''}
@@ -37,7 +39,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
         <div className='fr-mt-6w'>
           <TextInput
             name='startPath'
-            label='Chemin du répertoire'
+            label={STOCKAGE_PARAMS.startPath.label}
             placeholder='"/" par défaut'
             description='Chemin du répertoire contenant les fichiers du livrable. Le processus d’analyse prendra en compte tous les fichiers et répertoires accessibles à partir de ce chemin.'
             value={stockageParams.startPath || ''}
@@ -49,7 +51,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
           <div className='fr-col-12 fr-col-md-6'>
             <TextInput
               name='username'
-              label='Nom d’utilisateur'
+              label={STOCKAGE_PARAMS.username.label}
               description=''
               value={stockageParams.username || ''}
               autoComplete='off'
@@ -60,7 +62,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
           <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
             <TextInput
               name='password'
-              label='Mot de passe'
+              label={STOCKAGE_PARAMS.password.label}
               type='password'
               description=''
               value={stockageParams.password || ''}

--- a/components/suivi-form/livrables/stockage-form/http-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/http-params-inputs.js
@@ -2,6 +2,7 @@ import {useState} from 'react'
 import PropTypes from 'prop-types'
 
 import {isURLValid} from '@/components/suivi-form/livrables/utils/url.js'
+import {STOCKAGE_PARAMS} from '@/lib/utils/projet.js'
 
 import TextInput from '@/components/text-input.js'
 
@@ -22,7 +23,8 @@ const HttpParamsInputs = ({stockageParams, handleParams}) => {
   return (
     <div className='fr-mt-6v'>
       <TextInput
-        label='URL du serveur'
+        name='url'
+        label={STOCKAGE_PARAMS.url.label}
         description='Lien d’accès au(x) fichier(s)'
         value={url}
         placeholder='http://...'

--- a/components/suivi-form/livrables/stockage-form/sftp-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/sftp-params-inputs.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types'
 
+import {STOCKAGE_PARAMS} from '@/lib/utils/projet.js'
+
 import TextInput from '@/components/text-input.js'
 import NumberInput from '@/components/number-input.js'
 
@@ -26,7 +28,7 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
         <div className='fr-mt-6w'>
           <NumberInput
             name='port'
-            label='Port'
+            label={STOCKAGE_PARAMS.port.label}
             placeholder=''
             description='Port d’écoute du service SFTP'
             value={stockageParams.port || ''}
@@ -37,7 +39,7 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
         <div className='fr-mt-6w'>
           <TextInput
             name='startPath'
-            label='Chemin du répertoire'
+            label={STOCKAGE_PARAMS.startPath.label}
             placeholder='"/" par défaut'
             description='Chemin du répertoire contenant les fichiers du livrable. Le processus d’analyse prendra en compte tous les fichiers et répertoires accessibles à partir de ce chemin.'
             value={stockageParams.startPath || ''}
@@ -50,7 +52,7 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
             <TextInput
               isRequired
               name='username'
-              label='Nom d’utilisateur'
+              label={STOCKAGE_PARAMS.username.label}
               description=''
               value={stockageParams.username || ''}
               autoComplete='off'
@@ -62,7 +64,7 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
             <TextInput
               isRequired
               name='password'
-              label='Mot de passe'
+              label={STOCKAGE_PARAMS.password.label}
               type='password'
               description=''
               value={stockageParams.password || ''}

--- a/lib/utils/projet.js
+++ b/lib/utils/projet.js
@@ -47,4 +47,13 @@ export const REGIMES = {
   maj: {label: 'Mise à jour', color: '#fee9e5'},
   production: {label: 'Production', color: '#e7ca8e'}
 }
-/* eslint-enable  camelcase */
+
+export const STOCKAGE_PARAMS = {
+  host: {label: 'Nom d’hôte du service', defaultValue: 'Non renseigné'},
+  username: {label: 'Nom d’utilisateur', defaultValue: 'Non renseigné'},
+  password: {label: 'Mot de passe', defaultValue: 'Non renseigné'},
+  startPath: {label: 'Chemin du répertoire', defaultValue: '/ (défaut'},
+  port: {label: 'Port d’accès au service', defaultValue: 'Non renseigné'},
+  url: {label: 'URL du stockage', defaultValue: 'Non renseignée'},
+  secure: {label: 'Connexion sécurisée', defaultValue: false}
+}


### PR DESCRIPTION
## Évolutions
Création d'un lexique réutilisable pour les paramètres d'un stockage.

- `host` : 'Nom d’hôte du service'
- `username` : 'Nom d’utilisateur'
- `password` : 'Mot de passe'
- `startPath` : 'Chemin du répertoire'
- `port` : 'Port d’accès au service
- `url` : 'URL du stockage'
- `secure` : 'Connexion sécurisée'