### PR TITLE
Corrige le clic dans les paramètres de stockage

### DIFF
--- a/components/containers/dropdown-list.js
+++ b/components/containers/dropdown-list.js
@@ -10,8 +10,8 @@ const DropdownList = ({title, list, isDefaultOpen}) => {
   const toggleOpen = () => setIsOpen(!isOpen)
 
   return (
-    <div className='fr-grid-row' onClick={toggleOpen}>
-      <div className='fr-grid-row fr-col-12'>
+    <div className='fr-grid-row'>
+      <div className='fr-grid-row fr-col-12' onClick={toggleOpen}>
         <div className='data-title dropdown fr-mr-1w fr-grid-row'>{title}</div>
         <span className={`fr-icon-arrow-${isOpen ? 'down' : 'right'}-s-line`} />
       </div>

--- a/components/containers/dropdown-list.js
+++ b/components/containers/dropdown-list.js
@@ -12,7 +12,8 @@ const DropdownList = ({title, list, isDefaultOpen}) => {
   return (
     <div className='fr-grid-row' onClick={toggleOpen}>
       <div className='fr-grid-row fr-col-12'>
-        <div className='data-title dropdown fr-mr-1w fr-grid-row'>{title}</div><span className={`fr-icon-arrow-${isOpen ? 'down' : 'right'}-s-line`} />
+        <div className='data-title dropdown fr-mr-1w fr-grid-row'>{title}</div>
+        <span className={`fr-icon-arrow-${isOpen ? 'down' : 'right'}-s-line`} />
       </div>
 
       {isOpen && (
@@ -39,7 +40,7 @@ const DropdownList = ({title, list, isDefaultOpen}) => {
         wrapper-container {
           background: ${colors.grey975};
         }
-        
+
         .dropdown-data-title {
           color: ${colors.grey50};
           font-weight: bold;


### PR DESCRIPTION
## Contexte : 

Lorsque le composant `Dropdown` est ouvert, le clic sur le contenu enfant ferme le composant.

## Correction : 

Cette PR déplace l’événement `onClick` sur la partie supérieure afin d’éviter la fermeture lors du clic à l’intérieur de la partie "masquable"

Fix #354 



