### PR TITLE
Edition du stockage de livrable

### DIFF
--- a/components/suivi-form/livrables/livrable-form.js
+++ b/components/suivi-form/livrables/livrable-form.js
@@ -63,6 +63,8 @@ const initState = ({initialValues, fieldsValidations}) => {
 const LivrableForm = ({initialValues, isLivrableNameAvailable, onCancel, onSubmit}) => {
   const [form, dispatch] = useReducer(formReducer, initState({initialValues, fieldsValidations: {nom: isLivrableNameAvailable}}))
 
+  const [isStockageFormOpen, setIsStockageFormOpen] = useState(false)
+
   const livrableFormRef = useRef()
 
   const [errorMessage, setErrorMessage] = useState()
@@ -92,7 +94,13 @@ const LivrableForm = ({initialValues, isLivrableNameAvailable, onCancel, onSubmi
   }
 
   const handleLivrableStockage = e => {
+    setIsStockageFormOpen(false)
     setLivrableStockage(e)
+    livrableFormRef.current.scrollIntoView()
+  }
+
+  const handleStockageCancel = () => {
+    setIsStockageFormOpen(false)
     livrableFormRef.current.scrollIntoView()
   }
 
@@ -210,27 +218,28 @@ const LivrableForm = ({initialValues, isLivrableNameAvailable, onCancel, onSubmi
         </div>
 
         <div className='fr-col-12'>
-          {(livrableStockage?.stockage_params.host || livrableStockage?.stockage_params.url) && (
+          {(livrableStockage?.stockage_params.host || livrableStockage?.stockage_params.url) && !isStockageFormOpen && (
             <StockageCard
               type={livrableStockage.stockage}
               params={livrableStockage.stockage_params}
               generalSettings={{isPublic: livrableStockage.stockage_public, isDownloadable: livrableStockage.stockage_telechargement}}
+              handleEdition={() => setIsStockageFormOpen(true)}
               handleDelete={() => setLivrableStockage(null)}
             />
           )}
 
-          {livrableStockage?.stockage === null && (
+          {(isStockageFormOpen) && (
             <StockageForm
               initialValues={livrableStockage}
               handleLivrableStockage={handleLivrableStockage}
-              onCancel={() => setLivrableStockage(null)}
+              onCancel={handleStockageCancel}
             />
           )}
 
-          {!livrableStockage && (
-            <Button label='Ajouter un stockage' onClick={() => {
-              setLivrableStockage({stockage: null, stockage_params: {}})
-            }}
+          {!livrableStockage && !isStockageFormOpen && (
+            <Button
+              label='Ajouter un stockage'
+              onClick={() => setIsStockageFormOpen(true)}
             >
               Ajouter un stockage
             </Button>

--- a/components/suivi-form/livrables/stockage-card.js
+++ b/components/suivi-form/livrables/stockage-card.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import colors from '@/styles/colors.js'
 import {STOCKAGE_PARAMS} from '@/lib/utils/projet.js'
 
-const StockageCard = ({type, params, generalSettings, handleDelete}) => {
+const StockageCard = ({type, params, generalSettings, handleDelete, handleEdition}) => {
   const url = type === 'http' ? params.url : `${params.host}${params.port ? `:${params.port}` : ''}${params.startPath || ''}`
 
   return (
@@ -60,7 +60,16 @@ const StockageCard = ({type, params, generalSettings, handleDelete}) => {
         </div>
       </div>
 
-      <div className='fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-col-12 fr-col-lg-1 fr-p-0 fr-mt-1w fr-mt-md-0 buttons-container'>
+      <div className='fr-grid-row fr-grid-row--gutters fr-col-12 fr-col-lg-1 fr-p-0 buttons-container'>
+        <button
+          type='button'
+          className='fr-grid-row fr-col-lg-12 fr-grid-row--center fr-grid-row--middle fr-mr-2w update-button'
+          onClick={handleEdition}
+        >
+          <span className='fr-icon-edit-line fr-pr-1w fr-col-lg-12' aria-hidden='true' />
+          <div>Modifier</div>
+        </button>
+
         <button
           type='button'
           className='fr-grid-row fr-col-lg-12 fr-grid-row--center fr-grid-row--middle delete-button'
@@ -86,10 +95,17 @@ const StockageCard = ({type, params, generalSettings, handleDelete}) => {
           color: ${colors.blueFranceSun113};
         }
 
-        .delete-button {
+        .update-button, .delete-button {
           text-decoration: underline;
-          color: ${colors.error425};
           width: fit-content;
+        }
+
+        .update-button {
+          color: ${colors.blueFranceSun113};
+        }
+
+        .delete-button {
+          color: ${colors.error425};
         }
       `}</style>
     </div>
@@ -111,7 +127,8 @@ StockageCard.propTypes = {
     isPublic: PropTypes.bool,
     isDownloadable: PropTypes.bool
   }),
-  handleDelete: PropTypes.func.isRequired
+  handleDelete: PropTypes.func.isRequired,
+  handleEdition: PropTypes.func.isRequired
 }
 
 export default StockageCard

--- a/components/suivi-form/livrables/stockage-form/http-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/http-params-inputs.js
@@ -12,12 +12,14 @@ const HttpParamsInputs = ({stockageParams, handleParams}) => {
 
   function handleHttpChange(url) {
     setUrl(url)
+
     if (isURLValid(url)) {
       setErrorMessage(null)
-      handleParams({url})
     } else {
       setErrorMessage('Cette URL n’est pas valide')
     }
+
+    handleParams({url})
   }
 
   return (

--- a/components/suivi-form/livrables/stockage-form/http-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/http-params-inputs.js
@@ -1,47 +1,27 @@
-import {useState} from 'react'
 import PropTypes from 'prop-types'
 
-import {isURLValid} from '@/components/suivi-form/livrables/utils/url.js'
 import {STOCKAGE_PARAMS} from '@/lib/utils/projet.js'
 
 import TextInput from '@/components/text-input.js'
 
-const HttpParamsInputs = ({stockageParams, handleParams}) => {
-  const [url, setUrl] = useState(stockageParams?.url || '')
-  const [errorMessage, setErrorMessage] = useState(null)
-
-  function handleHttpChange(url) {
-    setUrl(url)
-
-    if (isURLValid(url)) {
-      setErrorMessage(null)
-    } else {
-      setErrorMessage('Cette URL n’est pas valide')
-    }
-
-    handleParams({url})
-  }
-
-  return (
-    <div className='fr-mt-6v'>
-      <TextInput
-        name='url'
-        label={STOCKAGE_PARAMS.url.label}
-        description='Lien d’accès au(x) fichier(s)'
-        value={url}
-        placeholder='http://...'
-        errorMessage={errorMessage}
-        onValueChange={e => handleHttpChange(e.target.value)}
-      />
-    </div>
-  )
-}
+const HttpParamsInputs = ({url, handleUrl, errorMessage}) => (
+  <div className='fr-mt-6v'>
+    <TextInput
+      name='url'
+      label={STOCKAGE_PARAMS.url.label}
+      description='Lien d’accès au(x) fichier(s)'
+      value={url}
+      placeholder='http://...'
+      errorMessage={errorMessage}
+      onValueChange={e => handleUrl(e.target.value)}
+    />
+  </div>
+)
 
 HttpParamsInputs.propTypes = {
-  stockageParams: PropTypes.shape({
-    url: PropTypes.string
-  }),
-  handleParams: PropTypes.func.isRequired
+  url: PropTypes.string,
+  handleUrl: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string
 }
 
 export default HttpParamsInputs

--- a/components/suivi-form/livrables/stockage-form/http-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/http-params-inputs.js
@@ -4,7 +4,7 @@ import {STOCKAGE_PARAMS} from '@/lib/utils/projet.js'
 
 import TextInput from '@/components/text-input.js'
 
-const HttpParamsInputs = ({url, handleUrl, errorMessage}) => (
+const HttpParamsInputs = ({url, handleUrl, validationMessage}) => (
   <div className='fr-mt-6v'>
     <TextInput
       name='url'
@@ -12,7 +12,7 @@ const HttpParamsInputs = ({url, handleUrl, errorMessage}) => (
       description='Lien d’accès au(x) fichier(s)'
       value={url}
       placeholder='http://...'
-      errorMessage={errorMessage}
+      errorMessage={validationMessage}
       onValueChange={e => handleUrl(e.target.value)}
     />
   </div>
@@ -21,7 +21,7 @@ const HttpParamsInputs = ({url, handleUrl, errorMessage}) => (
 HttpParamsInputs.propTypes = {
   url: PropTypes.string,
   handleUrl: PropTypes.func.isRequired,
-  errorMessage: PropTypes.string
+  validationMessage: PropTypes.string
 }
 
 export default HttpParamsInputs

--- a/components/suivi-form/livrables/stockage-form/index.js
+++ b/components/suivi-form/livrables/stockage-form/index.js
@@ -12,7 +12,7 @@ import Button from '@/components/button.js'
 import {isURLValid} from '@/components/suivi-form/livrables/utils/url.js'
 
 const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
-  const [errorMessage, setErrorMessage] = useState(null)
+  const [validationMessage, setValidationMessage] = useState(null)
   const [stockageType, setStockageType] = useState(initialValues?.stockage || undefined)
   const [stockageParams, setStockageParams] = useState(initialValues?.stockage_params || {})
   const [generalSettings, setGeneralSettings] = useState({
@@ -33,9 +33,9 @@ const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
     setStockageParams(prev => ({...prev, url}))
 
     if (isURLValid(url)) {
-      setErrorMessage(null)
+      setValidationMessage(null)
     } else {
-      setErrorMessage('Cette URL n’est pas valide')
+      setValidationMessage({httpParams: {url: 'Cette URL n’est pas valide'}})
     }
   }
 
@@ -73,7 +73,7 @@ const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
         <HttpParamsInputs
           url={stockageParams?.url}
           handleUrl={handleUrl}
-          errorMessage={errorMessage}
+          validationMessage={validationMessage?.httpParams.url}
         />
       )}
 

--- a/components/suivi-form/livrables/stockage-form/index.js
+++ b/components/suivi-form/livrables/stockage-form/index.js
@@ -77,7 +77,7 @@ const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
           isDisabled={stockageType === 'http' ? (!stockageParams.url || !isURLValid(stockageParams.url)) : !stockageParams.host}
           onClick={onSubmit}
         >
-          Valider le stockage
+          {(!initialValues || initialValues.stockage === null) ? 'Ajouter le serveur' : 'Modifier le serveur'}
         </Button>
         <Button
           style={{marginLeft: '1em'}}

--- a/components/suivi-form/livrables/stockage-form/index.js
+++ b/components/suivi-form/livrables/stockage-form/index.js
@@ -12,6 +12,7 @@ import Button from '@/components/button.js'
 import {isURLValid} from '@/components/suivi-form/livrables/utils/url.js'
 
 const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
+  const [errorMessage, setErrorMessage] = useState(null)
   const [stockageType, setStockageType] = useState(initialValues?.stockage || undefined)
   const [stockageParams, setStockageParams] = useState(initialValues?.stockage_params || {})
   const [generalSettings, setGeneralSettings] = useState({
@@ -28,10 +29,21 @@ const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
     })
   }
 
+  const handleUrl = url => {
+    setStockageParams(prev => ({...prev, url}))
+
+    if (isURLValid(url)) {
+      setErrorMessage(null)
+    } else {
+      setErrorMessage('Cette URL n’est pas valide')
+    }
+  }
+
   return (
     <div className='fr-col-12'>
       <div className='fr-col-12'>
         <SelectInput
+          isDisabled={Boolean(stockageType)}
           label='Type de stockage'
           value={stockageType}
           options={[
@@ -59,8 +71,9 @@ const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
 
       {stockageType === 'http' && (
         <HttpParamsInputs
-          stockageParams={stockageParams}
-          handleParams={setStockageParams}
+          url={stockageParams?.url}
+          handleUrl={handleUrl}
+          errorMessage={errorMessage}
         />
       )}
 

--- a/components/suivi-form/livrables/stockage-form/index.js
+++ b/components/suivi-form/livrables/stockage-form/index.js
@@ -71,11 +71,11 @@ const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
 
       <div className='fr-mt-3w'>
         <Button
-          label='Ajouter le serveur'
           isDisabled={stockageType === 'http' ? !stockageParams.url : !stockageParams.host}
+          label='Valider le stockage'
           onClick={onSubmit}
         >
-          {(!initialValues || initialValues.stockage === null) ? 'Ajouter le serveur' : 'Modifier le serveur'}
+          Valider le stockage
         </Button>
         <Button
           style={{marginLeft: '1em'}}

--- a/components/suivi-form/livrables/stockage-form/index.js
+++ b/components/suivi-form/livrables/stockage-form/index.js
@@ -10,11 +10,11 @@ import SelectInput from '@/components/select-input.js'
 import Button from '@/components/button.js'
 
 const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
-  const [stockageType, setStockageType] = useState(initialValues.stockage || undefined)
-  const [stockageParams, setStockageParams] = useState(initialValues.params || {})
+  const [stockageType, setStockageType] = useState(initialValues?.stockage || undefined)
+  const [stockageParams, setStockageParams] = useState(initialValues?.stockage_params || {})
   const [generalSettings, setGeneralSettings] = useState({
-    isPublic: initialValues.isPublic || false,
-    isDownloadable: initialValues.isDownloadable || false
+    isPublic: initialValues?.stockage_public || false,
+    isDownloadable: initialValues?.stockage_telechargement || false
   })
 
   const onSubmit = () => {
@@ -75,7 +75,7 @@ const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
           isDisabled={stockageType === 'http' ? !stockageParams.url : !stockageParams.host}
           onClick={onSubmit}
         >
-          Ajouter le serveur
+          {(!initialValues || initialValues.stockage === null) ? 'Ajouter le serveur' : 'Modifier le serveur'}
         </Button>
         <Button
           style={{marginLeft: '1em'}}

--- a/components/suivi-form/livrables/stockage-form/index.js
+++ b/components/suivi-form/livrables/stockage-form/index.js
@@ -9,6 +9,8 @@ import SftpParamsInputs from '@/components/suivi-form/livrables/stockage-form/sf
 import SelectInput from '@/components/select-input.js'
 import Button from '@/components/button.js'
 
+import {isURLValid} from '@/components/suivi-form/livrables/utils/url.js'
+
 const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
   const [stockageType, setStockageType] = useState(initialValues?.stockage || undefined)
   const [stockageParams, setStockageParams] = useState(initialValues?.stockage_params || {})
@@ -71,8 +73,8 @@ const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
 
       <div className='fr-mt-3w'>
         <Button
-          isDisabled={stockageType === 'http' ? !stockageParams.url : !stockageParams.host}
           label='Valider le stockage'
+          isDisabled={stockageType === 'http' ? (!stockageParams.url || !isURLValid(stockageParams.url)) : !stockageParams.host}
           onClick={onSubmit}
         >
           Valider le stockage


### PR DESCRIPTION
## Contexte

Actuellement, il n’est pas possible d’éditer un stockage sur un livrable.
Le stockage doit être supprimé puis recréé par l’utilisateur.

## Solution

Cette PR ajoute la possibilité d’éditer le stockage d’un livrable.

Fix #359 

