### PR TITLE
Passage de "host" et "port" sur la même ligne pour les stockages FTP/SFTP

### DIFF
--- a/components/suivi-form/livrables/stockage-form/ftp-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/ftp-params-inputs.js
@@ -11,8 +11,8 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
   }
 
   return (
-    <div>
-      <div className='fr-grid-row fr-mt-6w'>
+    <div className='fr-grid-row fr-grid-row--gutters fr-mt-6v'>
+      <div className='fr-grid-row fr-col-12'>
         <div className='fr-col-12 fr-col-md-6'>
           <TextInput
             isRequired
@@ -24,7 +24,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
             onValueChange={handleValuesChange}
           />
         </div>
-        <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
+        <div className='fr-col-12 fr-col-md-6 fr-pl-md-3w'>
           <NumberInput
             name='port'
             label={STOCKAGE_PARAMS.port.label}
@@ -36,7 +36,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
         </div>
       </div>
 
-      <div className='fr-mt-6w'>
+      <div className='fr-col-12'>
         <TextInput
           name='startPath'
           label={STOCKAGE_PARAMS.startPath.label}
@@ -47,7 +47,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
         />
       </div>
 
-      <div className='fr-grid-row fr-mt-6w'>
+      <div className='fr-grid-row fr-col-12'>
         <div className='fr-col-12 fr-col-md-6'>
           <TextInput
             name='username'
@@ -59,7 +59,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
           />
         </div>
 
-        <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
+        <div className='fr-col-12 fr-col-md-6 fr-pl-md-3w'>
           <TextInput
             name='password'
             label={STOCKAGE_PARAMS.password.label}
@@ -73,7 +73,7 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
       </div>
 
       <div
-        className='fr-checkbox-group fr-mt-3w'
+        className='fr-checkbox-group fr-col-12'
         onClick={() => handleParams({...stockageParams, secure: !stockageParams.secure})}
       >
         <input
@@ -86,17 +86,6 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
           Le serveur FTP est sécurisé (FTPS, TLS/SSL)
         </label>
       </div>
-
-      <style jsx>{`
-.input-container {
-  display: flex;
-  width: 400px;
-}
-
-.input-container label {
-  padding-left: 1em;
-}
-`}</style>
     </div>
   )
 }

--- a/components/suivi-form/livrables/stockage-form/ftp-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/ftp-params-inputs.js
@@ -12,20 +12,19 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
 
   return (
     <div>
-      <div className='fr-mt-6w'>
-        <TextInput
-          isRequired
-          name='host'
-          label={STOCKAGE_PARAMS.host.label}
-          placeholder='ftp3.ign.fr'
-          description='Nom d’hôte du serveur ou adresse IP'
-          value={stockageParams.host || ''}
-          onValueChange={handleValuesChange}
-        />
-      </div>
-
-      <div>
-        <div className='fr-mt-6w'>
+      <div className='fr-grid-row fr-mt-6w'>
+        <div className='fr-col-12 fr-col-md-6'>
+          <TextInput
+            isRequired
+            name='host'
+            label={STOCKAGE_PARAMS.host.label}
+            placeholder='ftp3.ign.fr'
+            description='Nom d’hôte du serveur ou adresse IP'
+            value={stockageParams.host || ''}
+            onValueChange={handleValuesChange}
+          />
+        </div>
+        <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
           <NumberInput
             name='port'
             label={STOCKAGE_PARAMS.port.label}
@@ -35,69 +34,69 @@ const FtpParamsInputs = ({stockageParams, handleParams}) => {
             onValueChange={handleValuesChange}
           />
         </div>
+      </div>
 
-        <div className='fr-mt-6w'>
+      <div className='fr-mt-6w'>
+        <TextInput
+          name='startPath'
+          label={STOCKAGE_PARAMS.startPath.label}
+          placeholder='"/" par défaut'
+          description='Chemin du répertoire contenant les fichiers du livrable. Le processus d’analyse prendra en compte tous les fichiers et répertoires accessibles à partir de ce chemin.'
+          value={stockageParams.startPath || ''}
+          onValueChange={handleValuesChange}
+        />
+      </div>
+
+      <div className='fr-grid-row fr-mt-6w'>
+        <div className='fr-col-12 fr-col-md-6'>
           <TextInput
-            name='startPath'
-            label={STOCKAGE_PARAMS.startPath.label}
-            placeholder='"/" par défaut'
-            description='Chemin du répertoire contenant les fichiers du livrable. Le processus d’analyse prendra en compte tous les fichiers et répertoires accessibles à partir de ce chemin.'
-            value={stockageParams.startPath || ''}
+            name='username'
+            label={STOCKAGE_PARAMS.username.label}
+            description=''
+            value={stockageParams.username || ''}
+            autoComplete='off'
             onValueChange={handleValuesChange}
           />
         </div>
 
-        <div className='fr-grid-row fr-mt-6w'>
-          <div className='fr-col-12 fr-col-md-6'>
-            <TextInput
-              name='username'
-              label={STOCKAGE_PARAMS.username.label}
-              description=''
-              value={stockageParams.username || ''}
-              autoComplete='off'
-              onValueChange={handleValuesChange}
-            />
-          </div>
-
-          <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
-            <TextInput
-              name='password'
-              label={STOCKAGE_PARAMS.password.label}
-              type='password'
-              description=''
-              value={stockageParams.password || ''}
-              autoComplete='off'
-              onValueChange={handleValuesChange}
-            />
-          </div>
-        </div>
-
-        <div
-          className='fr-checkbox-group fr-mt-3w'
-          onClick={() => handleParams({...stockageParams, secure: !stockageParams.secure})}
-        >
-          <input
-            type='checkbox'
-            name='secure'
-            checked={stockageParams.secure || false}
-            onChange={handleValuesChange}
+        <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
+          <TextInput
+            name='password'
+            label={STOCKAGE_PARAMS.password.label}
+            type='password'
+            description=''
+            value={stockageParams.password || ''}
+            autoComplete='off'
+            onValueChange={handleValuesChange}
           />
-          <label className='fr-label'>
-            Le serveur FTP est sécurisé (FTPS, TLS/SSL)
-          </label>
         </div>
       </div>
 
-      <style jsx>{`
-        .input-container {
-          display: flex;
-          width: 400px;
-        }
+      <div
+        className='fr-checkbox-group fr-mt-3w'
+        onClick={() => handleParams({...stockageParams, secure: !stockageParams.secure})}
+      >
+        <input
+          type='checkbox'
+          name='secure'
+          checked={stockageParams.secure || false}
+          onChange={handleValuesChange}
+        />
+        <label className='fr-label'>
+          Le serveur FTP est sécurisé (FTPS, TLS/SSL)
+        </label>
+      </div>
 
-        .input-container label {
-          padding-left: 1em;
-        }
-      `}</style>
+      <style jsx>{`
+.input-container {
+  display: flex;
+  width: 400px;
+}
+
+.input-container label {
+  padding-left: 1em;
+}
+`}</style>
     </div>
   )
 }

--- a/components/suivi-form/livrables/stockage-form/sftp-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/sftp-params-inputs.js
@@ -12,20 +12,19 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
 
   return (
     <div>
-      <div className='fr-mt-6w'>
-        <TextInput
-          isRequired
-          name='host'
-          label='Nom d’hôte'
-          placeholder='sftp3.ign.fr'
-          description='Nom d’hôte du serveur ou adresse IP'
-          value={stockageParams.host || ''}
-          onValueChange={handleValuesChange}
-        />
-      </div>
-
-      <div>
-        <div className='fr-mt-6w'>
+      <div className='fr-grid-row fr-mt-6w'>
+        <div className='fr-col-12 fr-col-md-6'>
+          <TextInput
+            isRequired
+            name='host'
+            label='Nom d’hôte'
+            placeholder='sftp3.ign.fr'
+            description='Nom d’hôte du serveur ou adresse IP'
+            value={stockageParams.host || ''}
+            onValueChange={handleValuesChange}
+          />
+        </div>
+        <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
           <NumberInput
             name='port'
             label={STOCKAGE_PARAMS.port.label}
@@ -35,43 +34,43 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
             onValueChange={handleValuesChange}
           />
         </div>
+      </div>
 
-        <div className='fr-mt-6w'>
+      <div className='fr-mt-6w'>
+        <TextInput
+          name='startPath'
+          label={STOCKAGE_PARAMS.startPath.label}
+          placeholder='"/" par défaut'
+          description='Chemin du répertoire contenant les fichiers du livrable. Le processus d’analyse prendra en compte tous les fichiers et répertoires accessibles à partir de ce chemin.'
+          value={stockageParams.startPath || ''}
+          onValueChange={handleValuesChange}
+        />
+      </div>
+
+      <div className='fr-grid-row fr-mt-6w'>
+        <div className='fr-col-12 fr-col-md-6'>
           <TextInput
-            name='startPath'
-            label={STOCKAGE_PARAMS.startPath.label}
-            placeholder='"/" par défaut'
-            description='Chemin du répertoire contenant les fichiers du livrable. Le processus d’analyse prendra en compte tous les fichiers et répertoires accessibles à partir de ce chemin.'
-            value={stockageParams.startPath || ''}
+            isRequired
+            name='username'
+            label={STOCKAGE_PARAMS.username.label}
+            description=''
+            value={stockageParams.username || ''}
+            autoComplete='off'
             onValueChange={handleValuesChange}
           />
         </div>
 
-        <div className='fr-grid-row fr-mt-6w'>
-          <div className='fr-col-12 fr-col-md-6'>
-            <TextInput
-              isRequired
-              name='username'
-              label={STOCKAGE_PARAMS.username.label}
-              description=''
-              value={stockageParams.username || ''}
-              autoComplete='off'
-              onValueChange={handleValuesChange}
-            />
-          </div>
-
-          <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
-            <TextInput
-              isRequired
-              name='password'
-              label={STOCKAGE_PARAMS.password.label}
-              type='password'
-              description=''
-              value={stockageParams.password || ''}
-              autoComplete='off'
-              onValueChange={handleValuesChange}
-            />
-          </div>
+        <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
+          <TextInput
+            isRequired
+            name='password'
+            label={STOCKAGE_PARAMS.password.label}
+            type='password'
+            description=''
+            value={stockageParams.password || ''}
+            autoComplete='off'
+            onValueChange={handleValuesChange}
+          />
         </div>
       </div>
 

--- a/components/suivi-form/livrables/stockage-form/sftp-params-inputs.js
+++ b/components/suivi-form/livrables/stockage-form/sftp-params-inputs.js
@@ -11,8 +11,8 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
   }
 
   return (
-    <div>
-      <div className='fr-grid-row fr-mt-6w'>
+    <div className='fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mt-6v'>
+      <div className='fr-grid-row fr-col-12'>
         <div className='fr-col-12 fr-col-md-6'>
           <TextInput
             isRequired
@@ -24,7 +24,7 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
             onValueChange={handleValuesChange}
           />
         </div>
-        <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
+        <div className='fr-col-12 fr-col-md-6 fr-pl-md-3w'>
           <NumberInput
             name='port'
             label={STOCKAGE_PARAMS.port.label}
@@ -36,7 +36,7 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
         </div>
       </div>
 
-      <div className='fr-mt-6w'>
+      <div className='fr-col-12'>
         <TextInput
           name='startPath'
           label={STOCKAGE_PARAMS.startPath.label}
@@ -47,7 +47,7 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
         />
       </div>
 
-      <div className='fr-grid-row fr-mt-6w'>
+      <div className='fr-grid-row fr-col-12'>
         <div className='fr-col-12 fr-col-md-6'>
           <TextInput
             isRequired
@@ -60,7 +60,7 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
           />
         </div>
 
-        <div className='fr-col-12 fr-mt-3w fr-mt-md-0 fr-col-md-6 fr-pl-md-3w'>
+        <div className='fr-col-12 fr-col-md-6 fr-pl-md-3w'>
           <TextInput
             isRequired
             name='password'
@@ -73,17 +73,6 @@ const SftpParamsInputs = ({stockageParams, handleParams}) => {
           />
         </div>
       </div>
-
-      <style jsx>{`
-        .input-container {
-          display: flex;
-          width: 400px;
-        }
-
-        .input-container label {
-          padding-left: 1em;
-        }
-      `}</style>
     </div>
   )
 }


### PR DESCRIPTION
Cette PR modifie l'affichage des champs "port" et "host" afin que ceux-ci soient présentés sur une seule ligne.

Fix #360 

Capture : 

Avant : 

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/1742e764-cd79-4b75-9b4c-85148ecb5b32)


Après : 

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/fdd0ce75-faa2-4078-a40d-396032e7d901)
