### PR TITLE
Ajout d’un bouton pour relancer le scan d’un stockage

### DIFF
--- a/backend/lib/api-scanner.js
+++ b/backend/lib/api-scanner.js
@@ -24,3 +24,11 @@ export async function askDownloadToken({stockageId}) {
   return token
 }
 
+export async function refreshScan({stockageId}) {
+  const stockage = await got.post(`${SCANNER_URL}/storages/${stockageId}/scan`, {
+    headers: {authorization: `Token ${SCANNER_ADMIN_TOKEN}`}
+  }).json()
+
+  return stockage
+}
+

--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -180,6 +180,8 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
           <div id='livrables'>
             <Livrables
               livrables={projetLivrables}
+              projetId={_id}
+              editCode={editCode}
               handleLivrables={setProjetLivrables}
               hasMissingData={hasMissingItemsOnValidation}
             />

--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -136,7 +136,7 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
     try {
       await refreshScan(_id, stockageId, editCode)
     } catch (error) {
-      setErrorMessage('La scan n’a pas pu être relancé : ' + error.message)
+      throw new Error('La scan n’a pas pu être relancé : ' + error.message)
     }
   }
 

--- a/components/suivi-form/index.js
+++ b/components/suivi-form/index.js
@@ -6,7 +6,7 @@ import {uniq} from 'lodash'
 
 import colors from '@/styles/colors.js'
 
-import {postSuivi, editProject} from '@/lib/suivi-pcrs.js'
+import {postSuivi, editProject, refreshScan} from '@/lib/suivi-pcrs.js'
 
 import {useInput} from '@/hooks/input.js'
 
@@ -132,6 +132,14 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
     }
   }
 
+  const handleRefreshScan = async stockageId => {
+    try {
+      await refreshScan(_id, stockageId, editCode)
+    } catch (error) {
+      setErrorMessage('La scan n’a pas pu être relancé : ' + error.message)
+    }
+  }
+
   return (
     <>
       <div className='form-header fr-my-5w'>
@@ -180,10 +188,9 @@ const SuiviForm = ({nom, nature, regime, livrables, acteurs, perimetres, subvent
           <div id='livrables'>
             <Livrables
               livrables={projetLivrables}
-              projetId={_id}
-              editCode={editCode}
               handleLivrables={setProjetLivrables}
               hasMissingData={hasMissingItemsOnValidation}
+              handleRefreshScan={handleRefreshScan}
             />
           </div>
 

--- a/components/suivi-form/livrables/index.js
+++ b/components/suivi-form/livrables/index.js
@@ -8,7 +8,7 @@ import Button from '@/components/button.js'
 import LivrableCard from '@/components/suivi-form/livrables/livrable-card.js'
 import LivrableForm from '@/components/suivi-form/livrables/livrable-form.js'
 
-const Livrables = ({livrables, hasMissingData, handleLivrables, projetId, editCode}) => {
+const Livrables = ({livrables, hasMissingData, handleLivrables, handleRefreshScan}) => {
   const [editedLivrable, setEditedLivrable] = useState(livrables?.length > 0 ? null : {})
 
   const onDelete = index => {
@@ -62,11 +62,10 @@ const Livrables = ({livrables, hasMissingData, handleLivrables, projetId, editCo
             ) : (
               <LivrableCard
                 livrable={livrable}
-                projetId={projetId}
-                editCode={editCode}
                 isDisabled={Boolean(editedLivrable)}
                 handleEdition={() => setEditedLivrable({livrable, index})}
                 handleDelete={() => onDelete(index)}
+                handleRefreshScan={handleRefreshScan}
               />
             )}
           </div>
@@ -112,8 +111,7 @@ Livrables.propTypes = {
   livrables: PropTypes.array.isRequired,
   hasMissingData: PropTypes.bool,
   handleLivrables: PropTypes.func.isRequired,
-  projetId: PropTypes.string,
-  editCode: PropTypes.string
+  handleRefreshScan: PropTypes.func
 }
 
 Livrables.defaultProps = {

--- a/components/suivi-form/livrables/index.js
+++ b/components/suivi-form/livrables/index.js
@@ -8,7 +8,7 @@ import Button from '@/components/button.js'
 import LivrableCard from '@/components/suivi-form/livrables/livrable-card.js'
 import LivrableForm from '@/components/suivi-form/livrables/livrable-form.js'
 
-const Livrables = ({livrables, hasMissingData, handleLivrables}) => {
+const Livrables = ({livrables, hasMissingData, handleLivrables, projetId, editCode}) => {
   const [editedLivrable, setEditedLivrable] = useState(livrables?.length > 0 ? null : {})
 
   const onDelete = index => {
@@ -62,6 +62,8 @@ const Livrables = ({livrables, hasMissingData, handleLivrables}) => {
             ) : (
               <LivrableCard
                 livrable={livrable}
+                projetId={projetId}
+                editCode={editCode}
                 isDisabled={Boolean(editedLivrable)}
                 handleEdition={() => setEditedLivrable({livrable, index})}
                 handleDelete={() => onDelete(index)}

--- a/components/suivi-form/livrables/index.js
+++ b/components/suivi-form/livrables/index.js
@@ -111,7 +111,9 @@ const Livrables = ({livrables, hasMissingData, handleLivrables, projetId, editCo
 Livrables.propTypes = {
   livrables: PropTypes.array.isRequired,
   hasMissingData: PropTypes.bool,
-  handleLivrables: PropTypes.func.isRequired
+  handleLivrables: PropTypes.func.isRequired,
+  projetId: PropTypes.string,
+  editCode: PropTypes.string
 }
 
 Livrables.defaultProps = {

--- a/components/suivi-form/livrables/livrable-card.js
+++ b/components/suivi-form/livrables/livrable-card.js
@@ -78,7 +78,7 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, projet
                 className='fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-refresh-line'
                 onClick={() => handleRefreshScan()}
               >
-                {refreshedScan ? 'Scan relancé' : 'Relancer le scan'}
+                {refreshedScan ? 'Scan en cours…' : 'Relancer le scan'}
               </button>
             )}
           </div>

--- a/components/suivi-form/livrables/livrable-card.js
+++ b/components/suivi-form/livrables/livrable-card.js
@@ -1,20 +1,35 @@
+/* eslint-disable camelcase */
+import {useState} from 'react'
 import PropTypes from 'prop-types'
 
 import colors from '@/styles/colors.js'
 
 import {shortDate} from '@/lib/date-utils.js'
+import {refreshScan} from '@/lib/suivi-pcrs.js'
 
 import {getNatures, getLicences, getDiffusions} from '@/components/suivi-form/livrables/utils/select-options.js'
 
-const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete}) => {
-  const {nom, nature, licence, avancement, diffusion, stockage} = livrable
+const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, projetId, editCode}) => {
+  const [refreshedScan, setRefreshedScan] = useState(false)
+  const {nom, nature, licence, avancement, diffusion, stockage, stockage_id} = livrable
   const dateLivraison = livrable.date_livraison
+
+  async function handleRefreshScan() {
+    try {
+      const response = await refreshScan(projetId, stockage_id, editCode)
+      if (response) {
+        setRefreshedScan(true)
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }
 
   return (
     <div className={`fr-grid-row card-container fr-grid-row--middle fr-grid-row--gutters ${isDisabled ? 'card-disable' : ''} fr-p-2w fr-col-12`}>
-      <div className='fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-col-lg-11'>
+      <div className='fr-grid-row fr-grid-row--middle fr-grid-row--center fr-grid-row--gutters fr-col-lg-10'>
         {/* ---------------------- Top ---------------------- */}
-        <div className='fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-col-12 infos-row'>
+        <div className='fr-grid-row fr-grid-row--gutters fr-grid-row--center fr-grid-row--middle fr-col-12 infos-row'>
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
             <div className='label fr-col-12'>Nom</div>
             <div className='fr-col-12 fr-text--sm fr-m-0'>{nom}</div>
@@ -29,10 +44,15 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete}) => {
             <div className='label fr-col-12'>Diffusion</div>
             <div className='fr-col-12 fr-text--sm fr-m-0'>{getDiffusions(diffusion) || 'N/A'}</div>
           </div>
+
+          <div className='fr-grid-row fr-col-12 fr-col-md-3'>
+            <div className='label fr-col-12'>Stockage</div>
+            <div className='fr-col-12 fr-text--sm fr-m-0'>{stockage?.toUpperCase() || 'N/A'}</div>
+          </div>
         </div>
 
         {/* ---------------------- Bottom ---------------------- */}
-        <div className='fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-col-12 infos-row'>
+        <div className='fr-grid-row fr-grid-row--gutters fr-grid-row--center fr-grid-row--middle fr-col-12 infos-row'>
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
             <div className='label fr-col-12'>Licence</div>
             <div className='fr-col-12 fr-text--sm fr-m-0'>{getLicences(licence)}</div>
@@ -46,17 +66,26 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete}) => {
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
             <div className='label fr-col-12'>Date de livraison</div>
             <div className='fr-col-12 fr-text--sm fr-m-0'>{dateLivraison ? shortDate(dateLivraison) : 'N/A'}</div>
+
           </div>
 
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
-            <div className='label fr-col-12'>Stockage</div>
-            <div className='fr-col-12 fr-text--sm fr-m-0'>{stockage?.toUpperCase() || 'N/A'}</div>
+            {stockage && (
+              <button
+                type='button'
+                disabled={refreshedScan}
+                className='fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-refresh-line'
+                onClick={() => handleRefreshScan()}
+              >
+                {refreshedScan ? 'Scan relancé' : 'Relancer le scan'}
+              </button>
+            )}
           </div>
         </div>
       </div>
 
       {!isDisabled && (
-        <div className='fr-grid-row fr-grid-row--gutters fr-col-12 fr-col-lg-1 fr-p-0 buttons-container'>
+        <div className='fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-col-12 fr-col-lg-2 fr-p-0 buttons-container'>
           <button
             type='button'
             className='fr-grid-row fr-col-lg-12 fr-grid-row--center fr-grid-row--middle fr-mr-2w update-button'
@@ -122,8 +151,11 @@ LivrableCard.propTypes = {
     diffusion: PropTypes.string,
     avancement: PropTypes.number,
     stockage: PropTypes.oneOf(['http', 'ftp', 'sftp']),
-    date_livraison: PropTypes.string // eslint-disable-line camelcase
+    stockage_id: PropTypes.string,
+    date_livraison: PropTypes.string
   }).isRequired,
+  projetId: PropTypes.string,
+  editCode: PropTypes.string,
   isDisabled: PropTypes.bool.isRequired,
   handleDelete: PropTypes.func.isRequired,
   handleEdition: PropTypes.func.isRequired

--- a/components/suivi-form/livrables/livrable-card.js
+++ b/components/suivi-form/livrables/livrable-card.js
@@ -1,22 +1,17 @@
 /* eslint-disable camelcase */
-import {useState} from 'react'
 import PropTypes from 'prop-types'
 
 import colors from '@/styles/colors.js'
 
 import {shortDate} from '@/lib/date-utils.js'
 
+import StockageRefresh from '@/components/suivi-form/livrables/stockage-refresh.js'
+
 import {getNatures, getLicences, getDiffusions} from '@/components/suivi-form/livrables/utils/select-options.js'
 
 const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, handleRefreshScan}) => {
-  const [refreshedScan, setRefreshedScan] = useState()
   const {nom, nature, licence, avancement, diffusion, stockage, stockage_id} = livrable
   const dateLivraison = livrable.date_livraison
-
-  async function handleRefresh() {
-    await handleRefreshScan(stockage_id)
-    setRefreshedScan(true)
-  }
 
   return (
     <div className={`fr-grid-row card-container fr-grid-row--middle fr-grid-row--gutters ${isDisabled ? 'card-disable' : ''} fr-p-2w fr-col-12`}>
@@ -64,14 +59,10 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, handle
 
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
             {stockage && (
-              <button
-                type='button'
-                disabled={refreshedScan}
-                className='fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-refresh-line'
-                onClick={() => handleRefresh()}
-              >
-                {refreshedScan ? 'Scan en cours…' : 'Relancer le scan'}
-              </button>
+              <StockageRefresh
+                handleRefreshScan={handleRefreshScan}
+                stockageId={stockage_id}
+              />
             )}
           </div>
         </div>

--- a/components/suivi-form/livrables/livrable-card.js
+++ b/components/suivi-form/livrables/livrable-card.js
@@ -11,6 +11,7 @@ import {getNatures, getLicences, getDiffusions} from '@/components/suivi-form/li
 
 const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, projetId, editCode}) => {
   const [refreshedScan, setRefreshedScan] = useState(false)
+  const [errorMessage, setErrorMessage] = useState(false)
   const {nom, nature, licence, avancement, diffusion, stockage, stockage_id} = livrable
   const dateLivraison = livrable.date_livraison
 
@@ -21,7 +22,7 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, projet
         setRefreshedScan(true)
       }
     } catch (error) {
-      console.log(error)
+      setErrorMessage('Un problème est survenu :' + error)
     }
   }
 
@@ -81,6 +82,9 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, projet
               </button>
             )}
           </div>
+          {errorMessage && (
+            <span className='error-message'>{errorMessage}</span>
+          )}
         </div>
       </div>
 
@@ -136,6 +140,10 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, projet
         }
 
         .delete-button {
+          color: ${colors.error425};
+        }
+
+        .error-message {
           color: ${colors.error425};
         }
       `}</style>

--- a/components/suivi-form/livrables/livrable-card.js
+++ b/components/suivi-form/livrables/livrable-card.js
@@ -5,25 +5,17 @@ import PropTypes from 'prop-types'
 import colors from '@/styles/colors.js'
 
 import {shortDate} from '@/lib/date-utils.js'
-import {refreshScan} from '@/lib/suivi-pcrs.js'
 
 import {getNatures, getLicences, getDiffusions} from '@/components/suivi-form/livrables/utils/select-options.js'
 
-const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, projetId, editCode}) => {
-  const [refreshedScan, setRefreshedScan] = useState(false)
-  const [errorMessage, setErrorMessage] = useState(false)
+const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, handleRefreshScan}) => {
+  const [refreshedScan, setRefreshedScan] = useState()
   const {nom, nature, licence, avancement, diffusion, stockage, stockage_id} = livrable
   const dateLivraison = livrable.date_livraison
 
-  async function handleRefreshScan() {
-    try {
-      const response = await refreshScan(projetId, stockage_id, editCode)
-      if (response) {
-        setRefreshedScan(true)
-      }
-    } catch (error) {
-      setErrorMessage('Un problème est survenu :' + error)
-    }
+  async function handleRefresh() {
+    await handleRefreshScan(stockage_id)
+    setRefreshedScan(true)
   }
 
   return (
@@ -76,15 +68,12 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, projet
                 type='button'
                 disabled={refreshedScan}
                 className='fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-refresh-line'
-                onClick={() => handleRefreshScan()}
+                onClick={() => handleRefresh()}
               >
                 {refreshedScan ? 'Scan en cours…' : 'Relancer le scan'}
               </button>
             )}
           </div>
-          {errorMessage && (
-            <span className='error-message'>{errorMessage}</span>
-          )}
         </div>
       </div>
 
@@ -142,10 +131,6 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, projet
         .delete-button {
           color: ${colors.error425};
         }
-
-        .error-message {
-          color: ${colors.error425};
-        }
       `}</style>
     </div>
   )
@@ -162,11 +147,10 @@ LivrableCard.propTypes = {
     stockage_id: PropTypes.string,
     date_livraison: PropTypes.string
   }).isRequired,
-  projetId: PropTypes.string,
-  editCode: PropTypes.string,
   isDisabled: PropTypes.bool.isRequired,
   handleDelete: PropTypes.func.isRequired,
-  handleEdition: PropTypes.func.isRequired
+  handleEdition: PropTypes.func.isRequired,
+  handleRefreshScan: PropTypes.func
 }
 
 export default LivrableCard

--- a/components/suivi-form/livrables/stockage-refresh.js
+++ b/components/suivi-form/livrables/stockage-refresh.js
@@ -24,7 +24,7 @@ const StockageRefresh = ({handleRefreshScan, stockageId}) => {
         className='fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-refresh-line'
         onClick={handleClick}
       >
-        {isScanRefreshing ? 'Scan en cours…' : 'Relancer le scan'}
+        {isScanRefreshing ? 'Scan demandé' : 'Relancer le scan'}
       </button>
       <span className='fr-col-12 error-message'>
         <small><i>{errorMessage}</i></small>

--- a/components/suivi-form/livrables/stockage-refresh.js
+++ b/components/suivi-form/livrables/stockage-refresh.js
@@ -1,0 +1,46 @@
+import {useState} from 'react'
+import PropTypes from 'prop-types'
+
+import colors from '@/styles/colors.js'
+
+const StockageRefresh = ({handleRefreshScan, stockageId}) => {
+  const [isScanRefreshing, setIsScanRefreshing] = useState(false)
+  const [errorMessage, setErrorMessage] = useState(null)
+
+  const handleClick = async () => {
+    try {
+      await handleRefreshScan(stockageId)
+      setIsScanRefreshing(true)
+    } catch (error) {
+      setErrorMessage(error.message)
+    }
+  }
+
+  return (
+    <div className='fr-grid-row'>
+      <button
+        type='button'
+        disabled={isScanRefreshing}
+        className='fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-refresh-line'
+        onClick={() => handleClick()}
+      >
+        {isScanRefreshing ? 'Scan en cours…' : 'Relancer le scan'}
+      </button>
+      <span className='fr-col-12 error-message'>
+        <small><i>{errorMessage}</i></small>
+      </span>
+      <style jsx>{`
+        .error-message {
+          color: ${colors.error425};
+        }
+      `}</style>
+    </div>
+  )
+}
+
+StockageRefresh.propTypes = {
+  handleRefreshScan: PropTypes.func,
+  stockageId: PropTypes.string
+}
+
+export default StockageRefresh

--- a/components/suivi-form/livrables/stockage-refresh.js
+++ b/components/suivi-form/livrables/stockage-refresh.js
@@ -22,7 +22,7 @@ const StockageRefresh = ({handleRefreshScan, stockageId}) => {
         type='button'
         disabled={isScanRefreshing}
         className='fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-refresh-line'
-        onClick={() => handleClick()}
+        onClick={handleClick}
       >
         {isScanRefreshing ? 'Scan en cours…' : 'Relancer le scan'}
       </button>

--- a/lib/suivi-pcrs.js
+++ b/lib/suivi-pcrs.js
@@ -111,6 +111,11 @@ export async function getStorageDownloadToken(projetId, stockageId) {
   return request(`/projets/${projetId}/stockages/${stockageId}/generate-download-token`, options)
 }
 
+export async function refreshScan(projetId, stockageId, token) {
+  const options = buildOptions({method: 'POST', token})
+  return request(`/projets/${projetId}/stockages/${stockageId}/refresh-scan`, options)
+}
+
 export async function getAllChanges(token) {
   const options = buildOptions({method: 'GET', token})
 

--- a/lib/utils/request.js
+++ b/lib/utils/request.js
@@ -1,7 +1,7 @@
 export async function request(url, options) {
   const res = await fetch(url, options)
 
-  if (res.status === 204) {
+  if (res.status === 204 || res.status === 202) {
     return res
   }
 

--- a/lib/utils/request.js
+++ b/lib/utils/request.js
@@ -1,7 +1,7 @@
 export async function request(url, options) {
   const res = await fetch(url, options)
 
-  if (res.status === 204 || res.status === 202) {
+  if ([202, 204].includes(res.status)) {
     return res
   }
 


### PR DESCRIPTION
Cette PR ajoute un bouton permettant de relancer le scan d’un stockage : 

### Backend : 
- Ajout d'une fonction qui appelle le scanner en lui fournissant le jeton d'authentification
- Ajout d'une route `/projets/:projetId/stockages/:stockageId/refresh-scan`

### Frontend : 
- Ajout d'une fonction qui appelle la route `/projets/:projetId/stockages/:stockageId/refresh-scan`
- Ajout d'un bouton dans le formulaire permettant de relancer le scan de stockage

### Captures : 

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/95023884-d7d5-49ef-982f-859e432eebdf)

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/696b1b24-718a-46dc-a67f-f9ab6c1f5109)

Fix #363 