### PR TITLE
Correction d'un problème empéchant l'affichage d'un projet avec stockage

### DIFF
--- a/components/projet/list-render-items.js
+++ b/components/projet/list-render-items.js
@@ -99,7 +99,7 @@ export const scanRenderItem = result => {
     {title: 'Nature', value: <Badge size='small' background='#fc916f'>PCRS raster</Badge>},
     {title: 'Format', value: result?.format && LIVRABLE_NATURES[result.format].label, defaultText: 'Non renseigné'},
     {title: 'Nombre de dalles', value: result?.numRasterFiles, defaultText: 'Non renseigné'},
-    {title: 'Projection', value: result?.projection, defaultText: 'Non renseignée'},
+    {title: 'Projection', value: result?.projection?.name, defaultText: 'Non renseignée'},
     {title: 'Poids', value: result?.sizeRasterFiles && formatBytes(result?.sizeRasterFiles), defaultText: 'Non renseignées'},
     {
       title: 'Bandes',


### PR DESCRIPTION
Cette demande d'ajout corrige un problème lié à l'affichage du stockage d'un projet.

Un des composants était hydraté par un objet alors que celui-ci attendait une chaine de caractère.

