### PR TITLE
Modification de l'affichage mots de passe dans le formulaire

### DIFF
--- a/components/suivi-form/livrables/stockage-card.js
+++ b/components/suivi-form/livrables/stockage-card.js
@@ -24,12 +24,12 @@ const StockageCard = ({type, params, generalSettings, handleDelete, handleEditio
 
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
             <div className='label fr-col-12'>{STOCKAGE_PARAMS.username.label}</div>
-            <div className='fr-col-12 fr-text--sm fr-m-0'>{params.username || 'N/A'}</div>
+            <div className='fr-col-12 fr-text--sm fr-m-0'>{params.username ? 'Enregistré' : 'N/A'}</div>
           </div>
 
           <div className='fr-grid-row fr-col-12 fr-col-md-3'>
             <div className='label fr-col-12'>{STOCKAGE_PARAMS.password.label}</div>
-            <div className='fr-col-12 fr-text--sm fr-m-0'>{params.password ? params.password.replaceAll(/./g, '*') : 'N/A'}</div>
+            <div className='fr-col-12 fr-text--sm fr-m-0'>{params.password ? 'Enregistré' : 'N/A'}</div>
           </div>
         </div>
 


### PR DESCRIPTION
Modification mineure pour retirer l'affichage de la longueur des mots de passe et des noms d'utilisateurs hors formulaire d'édition.

Fix #404 