### PR TITLE
Corrige la superposition des projets PCRS

### DIFF
--- a/components/map-sidebar/index.js
+++ b/components/map-sidebar/index.js
@@ -10,7 +10,7 @@ import Button from '@/components/button.js'
 
 const API_URL = process.env.NEXT_PUBLIC_URL || 'https://pcrs.beta.gouv.fr'
 
-const MapSidebar = ({projet, onClose, onProjetChange, projets}) => {
+const MapSidebar = ({projet, onClose, onProjetChange, projets, resetProjet}) => {
   const router = useRouter()
 
   const {
@@ -38,6 +38,7 @@ const MapSidebar = ({projet, onClose, onProjetChange, projets}) => {
         projectId={_id}
         projectName={nom}
         territoires={territoires}
+        resetProjet={resetProjet}
         onSidebarClose={onClose}
         onProjetChange={onProjetChange}
       />
@@ -100,6 +101,7 @@ MapSidebar.propTypes = {
   projet: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
   projets: PropTypes.array,
+  resetProjet: PropTypes.func.isRequired,
   onProjetChange: PropTypes.func
 }
 

--- a/components/map-sidebar/project-header.js
+++ b/components/map-sidebar/project-header.js
@@ -9,7 +9,7 @@ import Button from '@/components/button.js'
 
 const API_URL = process.env.NEXT_PUBLIC_URL || 'https://pcrs.beta.gouv.fr'
 
-const Header = ({projectId, projectName, territoires, projets, onProjetChange}) => {
+const Header = ({projectId, projectName, resetProjet, territoires, projets, onProjetChange}) => {
   const router = useRouter()
   const [isTerritoiresShow, setIsTerritoiresShow] = useState(false)
 
@@ -18,7 +18,16 @@ const Header = ({projectId, projectName, territoires, projets, onProjetChange}) 
   return (
     <div className='header'>
       <div>
-        <h1 className='fr-h4 fr-my-2w'>{projectName}</h1>
+        <div style={{display: 'flex', justifyContent: 'space-between'}}>
+          <h1 className='fr-h4 fr-my-2w'>{projectName}</h1>
+          <div>
+            <button
+              type='button'
+              className='fr-btn fr-icon-close-circle-line fr-btn--tertiary-no-outline'
+              onClick={resetProjet}
+            />
+          </div>
+        </div>
         <div className='fr-mb-3w'>
           <Button
             isWhite
@@ -122,6 +131,7 @@ Header.propTypes = {
   projectName: PropTypes.string.isRequired,
   territoires: PropTypes.array,
   projets: PropTypes.array,
+  resetProjet: PropTypes.func.isRequired,
   onProjetChange: PropTypes.func
 }
 

--- a/components/map/index.js
+++ b/components/map/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import {createRoot} from 'react-dom/client' // eslint-disable-line n/file-extension-in-import
 import {useEffect, useRef, useState, useCallback} from 'react'
 import PropTypes from 'prop-types'
@@ -13,11 +14,24 @@ import Legend from '@/components/map/legend.js'
 import MapToolBox from '@/components/map/map-tool-box.js'
 import AutocompleteInput from '@/components/autocomplete-input.js'
 
+const layerColors = {
+  investigation: '#ffe386',
+  convention_signee: '#d8ed75',
+  marche_public_en_cours: '#b9e45a',
+  prod_en_cours: '#a7f192',
+  controle_en_cours: '#87c1ea',
+  disponible: '#175c8b',
+  raster: '#fc916f',
+  vecteur: '#86b6d8',
+  mixte: '#cf7bb9'
+}
+
 const Map = ({isMobile, geometry, projetId, handleNewProject, handleSelectProjets}) => {
   const [layout, setLayout] = useState('projets-fills')
   const [acteurSearchInput, setActeurSearchInput] = useState('')
   const [foundActeurs, setFoundActeurs] = useState([])
   const [matchingIds, setMatchingIds] = useState([])
+  const [isNatureLayout, setIsNatureLayout] = useState(false)
 
   const normalize = string => deburr(string?.toLowerCase())
 
@@ -117,11 +131,13 @@ const Map = ({isMobile, geometry, projetId, handleNewProject, handleSelectProjet
       if (layout === 'projets-fills-nature') {
         mapRef.current.setLayoutProperty('projets-fills-nature', 'visibility', 'visible')
         mapRef.current.setLayoutProperty('projets-fills', 'visibility', 'none')
+        setIsNatureLayout(true)
       }
 
       if (layout === 'projets-fills') {
         mapRef.current.setLayoutProperty('projets-fills', 'visibility', 'visible')
         mapRef.current.setLayoutProperty('projets-fills-nature', 'visibility', 'none')
+        setIsNatureLayout(false)
       }
 
       // Filter by actors when actor is selected

--- a/components/map/index.js
+++ b/components/map/index.js
@@ -186,6 +186,10 @@ const Map = ({isMobile, geometry, projetId, handleNewProject, handleSelectProjet
       })
 
       selectedId.current = projetId
+    } else if (selectedId.current && mapRef.current.getLayer(`selected-${selectedId.current}`)) {
+      mapRef.current.removeLayer(`selected-${selectedId.current}`)
+      mapRef.current.removeSource(`selected-${selectedId.current}`)
+      selectedId.current = null
     }
   }, [projetId, geometry, isNatureLayout])
 

--- a/components/map/index.js
+++ b/components/map/index.js
@@ -31,7 +31,7 @@ const Map = ({isMobile, geometry, projetId, handleNewProject, handleSelectProjet
   const [acteurSearchInput, setActeurSearchInput] = useState('')
   const [foundActeurs, setFoundActeurs] = useState([])
   const [matchingIds, setMatchingIds] = useState([])
-  const [isNatureLayout, setIsNatureLayout] = useState(false)
+  const [isNatureLayout, setIsNatureLayout] = useState(false) // Which layout is selected (nature or statut)
 
   const normalize = string => deburr(string?.toLowerCase())
 

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -2805,6 +2805,15 @@
       }
     },
     {
+      "id": "projets-contours",
+      "type": "line",
+      "source": "projetsData",
+      "paint": {
+        "line-color": "black",
+        "line-width": 0.8
+      }
+    },
+    {
       "id": "projets-fills",
       "type": "fill",
       "source": "projetsData",
@@ -2820,12 +2829,7 @@
           "disponible", "#175c8b",
           "#0063cb"
         ],
-        "fill-opacity": [
-          "case",
-          ["boolean", ["feature-state", "hover"], false],
-          1,
-          0.5
-        ],
+        "fill-opacity": 0.5,
         "fill-outline-color": "grey"
       }
     },
@@ -2845,22 +2849,8 @@
           "mixte", "#cf7bb9",
           "white"
         ],
-        "fill-opacity": [
-          "case",
-          ["boolean", ["feature-state", "hover"], false],
-          1,
-          0.5
-        ],
+        "fill-opacity": 0.5,
         "fill-outline-color": "grey"
-      }
-    },
-    {
-      "id": "projets-contours",
-      "type": "line",
-      "source": "projetsData",
-      "paint": {
-        "line-color": "black",
-        "line-width": 0.8
       }
     },
     {

--- a/layouts/suivi-pcrs-map-layout/index.js
+++ b/layouts/suivi-pcrs-map-layout/index.js
@@ -9,7 +9,7 @@ import Map from '@/components/map/index.js'
 import MapSidebar from '@/components/map-sidebar/index.js'
 
 const SuiviPCRSMapLayout = props => {
-  const {projet, projets, onProjetChange, setIsOpen, handleNewProject, selectProjets, geometry} = props
+  const {projet, projets, onProjetChange, resetProjet, setIsOpen, handleNewProject, selectProjets, geometry} = props
   const {isMobileDevice} = useContext(DeviceContext)
 
   const Layout = useMemo(() => isMobileDevice ? Mobile : Desktop, [isMobileDevice])
@@ -18,6 +18,7 @@ const SuiviPCRSMapLayout = props => {
     <MapSidebar
       projet={projet}
       projets={projets}
+      resetProjet={resetProjet}
       onProjetChange={onProjetChange}
       onClose={() => setIsOpen(false)}
     />
@@ -53,6 +54,7 @@ SuiviPCRSMapLayout.propTypes = {
   projets: PropTypes.array,
   setIsOpen: PropTypes.func,
   handleNewProject: PropTypes.func.isRequired,
+  resetProjet: PropTypes.func.isRequired,
   onProjetChange: PropTypes.func.isRequired,
   selectProjets: PropTypes.func.isRequired
 }

--- a/pages/suivi-pcrs.js
+++ b/pages/suivi-pcrs.js
@@ -24,6 +24,10 @@ const PcrsMap = () => {
   const handleModal = () => setIsAuthentificationModalOpen(!isAuthentificationModalOpen)
   const handleNewProject = () => token ? router.push('/formulaire-suivi') : handleModal()
 
+  function resetProjet() {
+    setProjet(null)
+  }
+
   const selectProjets = useCallback(async projetsIds => {
     try {
       const promises = projetsIds.map(id => getProject(id, token))
@@ -76,6 +80,7 @@ const PcrsMap = () => {
           isOpen={isOpen}
           setIsOpen={setIsOpen}
           handleNewProject={handleNewProject}
+          resetProjet={() => resetProjet()}
           onProjetChange={handleProjet}
         />
       ) : (

--- a/pages/suivi-pcrs.js
+++ b/pages/suivi-pcrs.js
@@ -24,7 +24,7 @@ const PcrsMap = () => {
   const handleModal = () => setIsAuthentificationModalOpen(!isAuthentificationModalOpen)
   const handleNewProject = () => token ? router.push('/formulaire-suivi') : handleModal()
 
-  function resetProjet() {
+  const resetProjet = () => {
     setProjet(null)
   }
 
@@ -80,7 +80,7 @@ const PcrsMap = () => {
           isOpen={isOpen}
           setIsOpen={setIsOpen}
           handleNewProject={handleNewProject}
-          resetProjet={() => resetProjet()}
+          resetProjet={resetProjet}
           onProjetChange={handleProjet}
         />
       ) : (


### PR DESCRIPTION
Cette pull request corrige la superposition des projets lorsqu’ils sont sélectionnés, comme décrit dans cette [issue](https://github.com/openpcrs/pcrs.beta.gouv.fr/issues/399).

- Modification de l'affichage du projet sélectionné : 
Précédemment, pour afficher un projet sélectionné, nous modifions la transparence de la couleur du projet. Désormais, c’est un nouveau layer qui est superposé sur le layer de couleur, permettant de masquer les projets contenus dans un projet sélectionné.

- Ajout d’un bouton permettant de fermer la sélection d’un projet

### Captures
#### Avant : 

<img width="759" alt="image" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/ca4b10d5-38d8-437c-83e6-5243d56d2834">

#### Après : 

<img width="759" alt="image" src="https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/3a33c056-6faf-428d-bbfc-81a1a0e179e8">

#### En-tête du panneau latéral avec le bouton de fermeture : 

![image](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/eb434acf-b008-489f-9ed1-132da1e9c9cb)


Fix #399 