### PR TITLE
Corrige un oubli lors de l'ajout de DXF

### DIFF
--- a/backend/lib/projets-validator.js
+++ b/backend/lib/projets-validator.js
@@ -297,7 +297,8 @@ const livrablesSchemaUpdate = Joi.object().keys({
   nature: Joi.valid(
     'geotiff',
     'jpeg2000',
-    'gml'
+    'gml',
+    'dxf'
   ).messages({
     'any.only': 'Cette nature n’est pas valide'
   }),


### PR DESCRIPTION
Dans la pull request #412, nous avons oublié d’ajouter DXF dans la partie `livrablesSchemaUpdate` empêchant la modification d’un projet contenant un livrable de nature "DXF".

Cette pull request ajoute ce champ pour corriger le problème.