### PR TITLE
Ajoute un lien sur le nom du projet dans la partie gestion

### DIFF
--- a/components/gestion-admin/changes.js
+++ b/components/gestion-admin/changes.js
@@ -1,5 +1,6 @@
 import {useEffect, useCallback, useState} from 'react'
 import PropTypes from 'prop-types'
+import Link from 'next/link'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import {fr} from 'date-fns/locale'
 
@@ -81,7 +82,10 @@ const Changes = ({token}) => {
 
                   return (
                     <tr key={change.nom}>
-                      <td className='fr-p-2w'><b>{change?.nom}</b></td>
+                      <td className='fr-p-2w'><b>
+                        <Link href={`/projet/${change._id}`}>
+                          {change?.nom}
+                        </Link></b></td>
                       <td className='fr-p-2w'>{lastChange}</td>
                       <td className='fr-p-2w'><i>{`(Il y a ${formatDistanceToNow(modificationTime, {locale: fr})})`}</i></td>
                     </tr>


### PR DESCRIPTION
## Problème : 

Récemment un projet a été créé avec le nom "PCRS ". Nous avons eu des difficultés à retrouver le projet en question sur la carte de suivi.

## Solution : 

Cette PR ajoute un lien sur le nom du projet dans la liste des projets modifié, permettant d’accéder rapidement à la page du projet.

## Capture : 

![Enregistrement de l’écran 2024-05-30 à 11 13 33](https://github.com/openpcrs/pcrs.beta.gouv.fr/assets/56537238/81162e73-252a-4c63-a668-ee1004d97db8)
