### PR TITLE
Supprime le lancement du script de migration au build 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "NODE_ENV=production node backend/index.js",
     "lint": "xo",
     "test": "ava",
-    "scalingo-postbuild": "yarn download-contours && node scripts/migration-v05.js && next build"
+    "scalingo-postbuild": "yarn download-contours && next build"
   },
   "dependencies": {
     "@etalab/decoupage-administratif": "^3.1.1",


### PR DESCRIPTION
Cette PR supprime la commande qui lance le script de migration au démarrage de l'application sur Scalingo