### PR TITLE
Supprime les espaces autour des valeurs de stockage de livrables

### DIFF
--- a/components/suivi-form/livrables/stockage-form/index.js
+++ b/components/suivi-form/livrables/stockage-form/index.js
@@ -11,6 +11,15 @@ import Button from '@/components/button.js'
 
 import {isURLValid} from '@/components/suivi-form/livrables/utils/url.js'
 
+const trimObjectValues = obj => {
+  const result = {}
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = typeof value === 'string' ? value.trim() : value
+  }
+
+  return result
+}
+
 const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
   const [validationMessage, setValidationMessage] = useState(null)
   const [isSubmitable, setIsSubmitable] = useState(false)
@@ -22,11 +31,13 @@ const StockageForm = ({initialValues, handleLivrableStockage, onCancel}) => {
   })
 
   const onSubmit = () => {
+    const trimmedParams = trimObjectValues(stockageParams)
+
     handleLivrableStockage({
       stockage: stockageType,
       stockage_public: generalSettings.isPublic,
       stockage_telechargement: generalSettings.isDownloadable,
-      stockage_params: stockageParams
+      stockage_params: trimmedParams
     })
   }
 


### PR DESCRIPTION
Il semble que des espaces dans les paramètres de connexion aux stockages des livrables puissent poser un problème lors du scan de celui-ci.

Cette pull request ajoute une fonction permettant de supprimer les espaces autour des valeurs des paramètres de stockage d’un livrable.