### PR TITLE
Corrige le problème de statut sur les exports csv 

### DIFF
--- a/backend/export/csv.js
+++ b/backend/export/csv.js
@@ -4,6 +4,7 @@ import Wellknown from 'wellknown'
 
 import {getProjets} from '../lib/models/projets.js'
 import {buildGeometryFromTerritoires} from '../lib/territoires.js'
+import {findClosestEtape} from '../../shared/find-closest-etape.js'
 
 async function computeWkt(perimetres) {
   const perimetresGeojson = await buildGeometryFromTerritoires(perimetres)
@@ -19,7 +20,7 @@ export async function exportProjetsAsCSV(includes_wkt) {
       nom: projet.nom,
       regime: projet.regime,
       nature: projet.nature,
-      statut: projet.etapes.length > 0 ? projet.etapes.at(-1).statut : '',
+      statut: projet.etapes.length > 0 ? findClosestEtape(projet.etapes).statut : '',
       investigation_date: projet.etapes.find(e => e.statut === 'investigation')?.date_debut || '',
       convention_signee_date: projet.etapes.find(e => e.statut === 'convention_signee')?.date_debut || '',
       marche_public_en_cours_date: projet.etapes.find(e => e.statut === 'marche_public_en_cours')?.date_debut || '',


### PR DESCRIPTION
L’exportation des données en CSV renvoyait la mauvaise valeur pour le statut.
Dans l’exportation, le statut était basé sur la dernière étape du projet, sans vérifier si cette date était dans le passé ou dans le futur.

Cette pull request modifie la façon d’exporter le statut : Il est désormais basé sur l’étape passée la plus proche, évitant ainsi d’afficher un statut qui n’a pas encore débuté.

J’ai réutilisé la fonction `findClosestEtape` déjà présente.

Fix #427 