### PR TITLE
Corrige l'affichage du message dans les livrables

### DIFF
--- a/components/projet/scan-result.js
+++ b/components/projet/scan-result.js
@@ -21,7 +21,7 @@ const ScanResult = ({raster, lastSuccessfulScan, dataFiles, brokenDataFiles, bro
 
       <div>
         <p className='fr-mb-1w'>
-          <span className='files-total'>{dataFiles}</span> fichier{dataFiles > 1 && 's'}  de données scannées
+          <span className='files-total'>{dataFiles}</span> fichier{dataFiles > 1 && 's'}  de données scannés
           {brokenDataFiles > 1 && (
             <>
               <span> dont <span className='error-total'> {brokenDataFiles} fichier{brokenDataFiles > 1 && 's'} en erreur</span>.</span>

--- a/components/suivi-form/livrables/livrable-card.js
+++ b/components/suivi-form/livrables/livrable-card.js
@@ -138,16 +138,16 @@ const LivrableCard = ({livrable, isDisabled, handleEdition, handleDelete, handle
                 stockageId={stockage_id}
               />
             )}
-            {stockage_erreur && (
-              <span>Erreur : {stockage_erreur}</span>
-            )}
-            {error && (
-              <span className='fr-error-text'>Erreur : {error}</span>
-            )}
-            {message && (
-              <span className='fr-text--sm'>{message}</span>
-            )}
           </div>
+          {stockage_erreur && (
+            <span>Erreur : {stockage_erreur}</span>
+          )}
+          {error && (
+            <span className='fr-error-text fr-col-lg-12 fr-grid-row fr-grid-row--center'>Erreur : {error}</span>
+          )}
+          {message && (
+            <span className='fr-col-lg-12 fr-grid-row fr-grid-row--center'>{message}</span>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Cette PR modifie l’affichage du message sous le bouton pour relancer le scan.

Avant : 

![image](https://github.com/user-attachments/assets/bf44e61f-591c-42b5-a3d3-198f116b67f7)

Après : 

![image](https://github.com/user-attachments/assets/c26654ba-660e-49d5-b273-ae52c0e9211c)
