### PR TITLE
Export de territoires.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Puis compléter les champs suivants :
 | `/data/livrables.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des livrables des projets PCRS* |
 | `/data/tours-de-table.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des tours de table des projets PCRS* |
 | `/data/subventions.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des subventions des projets PCRS* |
-| `/data/perimetres.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des territoires* |
+| `/data/territoires.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des territoires* |
 | `/data/editor-keys.csv`| **GET** | *Retourne l’ensemble des codes d’édition des projets (Cette route est réservée aux administrateurs)* |
 | `/ask-code`| **POST** | *Faire une demande de création de projet. Cette route attend un objet `{"email": email du demandeur}`* |
 | `/check-code`| **POST** | *Vérifie la validité du code envoyé par email. Cette route attend un objet `{"email": email du demandeur, "pinCode": code envoyé par mail}`* |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Puis compléter les champs suivants :
 | `/data/livrables.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des livrables des projets PCRS* |
 | `/data/tours-de-table.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des tours de table des projets PCRS* |
 | `/data/subventions.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des subventions des projets PCRS* |
+| `/data/perimetres.csv`| **GET** | *Retourne un fichier CSV contenant l’ensemble des territoires* |
 | `/data/editor-keys.csv`| **GET** | *Retourne l’ensemble des codes d’édition des projets (Cette route est réservée aux administrateurs)* |
 | `/ask-code`| **POST** | *Faire une demande de création de projet. Cette route attend un objet `{"email": email du demandeur}`* |
 | `/check-code`| **POST** | *Vérifie la validité du code envoyé par email. Cette route attend un objet `{"email": email du demandeur, "pinCode": code envoyé par mail}`* |

--- a/backend/export/csv.js
+++ b/backend/export/csv.js
@@ -148,7 +148,7 @@ export async function exportEditorKeys() {
   return Papa.unparse(rows)
 }
 
-export async function exportPerimetres() {
+export async function exportTerritoires() {
   const projets = await getProjets()
   const rows = []
 

--- a/backend/export/csv.js
+++ b/backend/export/csv.js
@@ -147,3 +147,22 @@ export async function exportEditorKeys() {
 
   return Papa.unparse(rows)
 }
+
+export async function exportPerimetres() {
+  const projets = await getProjets()
+  const rows = []
+
+  for (const projet of projets) {
+    for (const perimetre of projet.perimetres) {
+      const natureAndRef = perimetre.split(':')
+
+      rows.push({
+        ref_projet: projet._id,
+        nature_territoire: natureAndRef[0],
+        reference: natureAndRef[1]
+      })
+    }
+  }
+
+  return Papa.unparse(rows)
+}

--- a/backend/routes/data.js
+++ b/backend/routes/data.js
@@ -2,7 +2,7 @@ import express from 'express'
 import {ensureAdmin} from '../auth/middleware.js'
 import w from '../util/w.js'
 
-import {exportProjetsAsCSV, exportLivrablesAsCSV, exportToursDeTableAsCSV, exportSubventionsAsCSV, exportProjectsChangeLog, exportEditorKeys, exportPerimetres} from '../export/csv.js'
+import {exportProjetsAsCSV, exportLivrablesAsCSV, exportToursDeTableAsCSV, exportSubventionsAsCSV, exportProjectsChangeLog, exportEditorKeys, exportTerritoires} from '../export/csv.js'
 import {computeDallesGeoJSON, computeLivrablesGeoJSON} from '../export/stockage.js'
 
 const dataRoutes = new express.Router()
@@ -55,10 +55,10 @@ dataRoutes.get('/editor-keys.csv', w(ensureAdmin), w(async (req, res) => {
   res.attachment('editor-keys.csv').type('csv').send(editorKeysCSVFile)
 }))
 
-dataRoutes.get('/perimetres.csv', w(async (req, res) => {
-  const perimetresCSVFile = await exportPerimetres()
+dataRoutes.get('/territoires.csv', w(async (req, res) => {
+  const perimetresCSVFile = await exportTerritoires()
 
-  res.attachment('perimetres.csv').type('csv').send(perimetresCSVFile)
+  res.attachment('territoires.csv').type('csv').send(perimetresCSVFile)
 }))
 
 export default dataRoutes

--- a/backend/routes/data.js
+++ b/backend/routes/data.js
@@ -2,7 +2,7 @@ import express from 'express'
 import {ensureAdmin} from '../auth/middleware.js'
 import w from '../util/w.js'
 
-import {exportProjetsAsCSV, exportLivrablesAsCSV, exportToursDeTableAsCSV, exportSubventionsAsCSV, exportProjectsChangeLog, exportEditorKeys} from '../export/csv.js'
+import {exportProjetsAsCSV, exportLivrablesAsCSV, exportToursDeTableAsCSV, exportSubventionsAsCSV, exportProjectsChangeLog, exportEditorKeys, exportPerimetres} from '../export/csv.js'
 import {computeDallesGeoJSON, computeLivrablesGeoJSON} from '../export/stockage.js'
 
 const dataRoutes = new express.Router()
@@ -53,6 +53,12 @@ dataRoutes.get('/editor-keys.csv', w(ensureAdmin), w(async (req, res) => {
   const editorKeysCSVFile = await exportEditorKeys()
 
   res.attachment('editor-keys.csv').type('csv').send(editorKeysCSVFile)
+}))
+
+dataRoutes.get('/perimetres.csv', w(async (req, res) => {
+  const perimetresCSVFile = await exportPerimetres()
+
+  res.attachment('perimetres.csv').type('csv').send(perimetresCSVFile)
 }))
 
 export default dataRoutes


### PR DESCRIPTION
Cette PR ajoute une route permettant de télécharger un export CSV de la liste des territoires.

Extrait du fichier exporté : 

```csv
ref_projet,nature_territoire,reference
64281c3f4340ffbf17bf2de0,departement,08
64281c3f4340ffbf17bf2de2,departement,09
64281c3f4340ffbf17bf2de4,departement,10
64281c3f4340ffbf17bf2de6,epci,200067874
64281c3f4340ffbf17bf2de8,epci,200067874
64281c3f4340ffbf17bf2dea,epci,200067783
64281c3f4340ffbf17bf2dec,epci,246700488
64281c3f4340ffbf17bf2dee,epci,200069052
``` 

Détails : 
-  Création fonction `exportTerritoires`
- Ajout de la route `data/territoires.csv`
- Mise à jour du README

Fix #456 